### PR TITLE
139 sequential audio

### DIFF
--- a/packages/vue/src/base-course/Components/AudioAutoPlayer.vue
+++ b/packages/vue/src/base-course/Components/AudioAutoPlayer.vue
@@ -13,6 +13,8 @@ import SkldrMouseTrap from '../../SkldrMouseTrap';
 
 @Component({})
 export default class AudioAutoPlayer extends Vue {
+  private static LOCK: AudioAutoPlayer | null = null;
+
   @Prop({
     required: true,
   })
@@ -66,8 +68,14 @@ export default class AudioAutoPlayer extends Vue {
   }
 
   private play() {
-    this.playing = true;
-    this.playByIndex(0);
+    if (AudioAutoPlayer.LOCK === null || AudioAutoPlayer.LOCK === this) {
+      AudioAutoPlayer.LOCK = this;
+      this.playing = true;
+      this.playByIndex(0);
+    } else {
+      // lock held by another card - check again in _x_ ms
+      setTimeout(this.play, 100);
+    }
   }
 
   private playByIndex(n: number) {

--- a/packages/vue/src/base-course/Components/AudioAutoPlayer.vue
+++ b/packages/vue/src/base-course/Components/AudioAutoPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn v-on:click="play" large raised icon color="primary">
+  <v-btn v-on:click="play" large raised icon v-bind:class="playing ? 'primary lighten-3 playing' : 'primary'">
     <v-icon>volume_up</v-icon>
   </v-btn>
 </template>
@@ -115,3 +115,20 @@ export default class AudioAutoPlayer extends Vue {
   }
 }
 </script>
+
+<style scoped>
+.playing {
+  /* transform: rotate(3deg) scale(1.15); */
+  animation: 0.85s ease-in-out infinite alternate pulse;
+  z-index: 1;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.15);
+  }
+}
+</style>

--- a/packages/vue/src/base-course/Components/AudioAutoPlayer.vue
+++ b/packages/vue/src/base-course/Components/AudioAutoPlayer.vue
@@ -5,15 +5,16 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Prop, Component } from 'vue-property-decorator';
-import { log } from 'util';
 import { setTimeout } from 'timers';
+import { log } from 'util';
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
 import SkldrMouseTrap from '../../SkldrMouseTrap';
 
 @Component({})
 export default class AudioAutoPlayer extends Vue {
   private static LOCK: AudioAutoPlayer | null = null;
+  private static playbackGap: number = 500;
 
   @Prop({
     required: true,
@@ -45,6 +46,9 @@ export default class AudioAutoPlayer extends Vue {
 
   private stop() {
     this.playing = false;
+    setTimeout(() => {
+      AudioAutoPlayer.LOCK == null;
+    }, AudioAutoPlayer.playbackGap);
 
     this.playTimeouts.forEach((timeOut) => {
       clearTimeout(timeOut);
@@ -91,6 +95,14 @@ export default class AudioAutoPlayer extends Vue {
             }
           }, delay)
         );
+      } else {
+        setTimeout(() => {
+          this.playing = false;
+        }, this.audioElems[n].duration * 1000);
+        setTimeout(() => {
+          // release the AudioAutoPlayer lock - let other elements run
+          AudioAutoPlayer.LOCK = null;
+        }, this.audioElems[n].duration * 1000 + AudioAutoPlayer.playbackGap);
       }
     } else {
       setTimeout(this.playByIndex, 100, n);


### PR DESCRIPTION
feat:
- allow multiple cards containing audio to be displayed simultaneously, without speaking over one another
- fixes workflow on `arrange` for audio-heavy courses