### PR TITLE
Fix: tags added on card authoring now applied to cards

### DIFF
--- a/packages/vue/src/components/Edit/ViewableDataInputForm/DataInputForm.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/DataInputForm.vue
@@ -454,7 +454,8 @@ export default class DataInputForm extends SkldrVue {
             this.datashapeDescriptor.course,
             this.dataShape,
             input,
-            this.$store.state._user!.username
+            this.$store.state._user!.username,
+            this.$refs.tagsInput.tags.map((t) => t.text)
             // generic (non-required by datashape) attachments here
           );
         })
@@ -467,10 +468,6 @@ export default class DataInputForm extends SkldrVue {
         });
         const ti = this.$refs.tagsInput;
         if (ti.tags.length) {
-          for (let i = 0; i < ti.tags.length; i++) {
-            // apply configured tags to the newly created card
-            await addTagToCard(this.courseCfg.courseID!, result[0].id, ti.tags[i].text);
-          }
           // pull down any tags just added for auto-complete suggest
           ti.updateAvailableCourseTags();
           // clear applied tags


### PR DESCRIPTION
... previously the selected tags were receiving a reference to the added `note`, not the cards generated by the `note`.

It is worth considering:
- is it worthwhile for `note`s to be taggable?
- questionTypes?
- templates? (when they exist)

Or should these things in and of themselves be treated as tag(gish) by the engine?