### PR TITLE
139 prioritize new content

### DIFF
--- a/packages/vue/src/db/courseDB.ts
+++ b/packages/vue/src/db/courseDB.ts
@@ -77,13 +77,19 @@ export class CourseDB implements StudyContentSource {
     });
   }
 
-  public async getInexperiencedCards(limit: number = 2): Promise<string[]> {
+  public async getInexperiencedCards(limit: number = 2) {
     return (
       await this.db.query('cardsByInexperience', {
         limit,
       })
     ).rows.map((r) => {
-      return `${this.id}-${r.id}`;
+      const ret = {
+        courseId: this.id,
+        cardId: r.id,
+        count: r.key,
+        elo: r.value,
+      };
+      return ret;
     });
   }
 
@@ -735,6 +741,7 @@ export async function updateCardElo(courseID: string, cardID: string, elo: Cours
     // checking against null, undefined, NaN
     const cDB = getCourseDB(courseID);
     const card = await cDB.get<CardData>(cardID);
+    console.log(`Replacing ${JSON.stringify(card.elo)} with ${JSON.stringify(elo)}`);
     card.elo = elo;
     return cDB.put(card); // race conditions - is it important? probably not (net-zero effect)
   }

--- a/packages/vue/src/db/courseDB.ts
+++ b/packages/vue/src/db/courseDB.ts
@@ -76,6 +76,17 @@ export class CourseDB implements StudyContentSource {
       };
     });
   }
+
+  public async getInexperiencedCards(limit: number = 2): Promise<string[]> {
+    return (
+      await this.db.query('cardsByInexperience', {
+        limit,
+      })
+    ).rows.map((r) => {
+      return `${this.id}-${r.id}`;
+    });
+  }
+
   public async getCardsByEloLimits(low: number = 0, high: number = Number.MAX_SAFE_INTEGER) {
     return (
       await this.db.query('elo', {


### PR DESCRIPTION
Currently, the `Arrange` view on a course pulls random cards which the current user "seems qualified" to sort (ie, cards at or below the user's skill level).

In this PR, the `Arrange` view pulls cards according to their level of unsortedness. IE, cards that have never been compared to others are queued.

This should:
- improve the speed at which new course content gets accurately integrated into a course
- provide for an easy-to-reason-about priority list for course authors. Courses with large amounts of low-experience content can reject further content authoring in favor of content sorting.

NB: merge to `deploy` will not work, and depends on further progress with #144, specifically, successful redeployment of the `express` package.