### PR TITLE
Fix `course`/`tag` previews when cards have been deleted

### DIFF
--- a/packages/vue/src/components/Courses/CourseCardBrowser.vue
+++ b/packages/vue/src/components/Courses/CourseCardBrowser.vue
@@ -139,7 +139,7 @@ export default class CourseCardBrowser extends SkldrVue {
   private delBtn: boolean = false;
 
   private clearSelections(exception: string = '') {
-    this.cards.forEach((card) => {
+    this.cards.forEach(card => {
       if (card.id !== exception) {
         card.isOpen = false;
       }
@@ -151,7 +151,7 @@ export default class CourseCardBrowser extends SkldrVue {
   private async deleteCard(c: string) {
     const res = await this.courseDB.removeCard(c.split('-')[1]);
     if (res.ok) {
-      this.cards = this.cards.filter((card) => card.id != c);
+      this.cards = this.cards.filter(card => card.id != c);
       this.clearSelections();
     }
   }
@@ -184,7 +184,7 @@ export default class CourseCardBrowser extends SkldrVue {
   private async populateTableData() {
     if (this._tag) {
       const tag = await getTag(this._id, this._tag);
-      this.cards = tag.taggedCards.map((c) => {
+      this.cards = tag.taggedCards.map(c => {
         return { id: `${this._id}-${c}`, isOpen: false };
       });
     } else {
@@ -195,7 +195,7 @@ export default class CourseCardBrowser extends SkldrVue {
           limit: 25,
           page: this.page - 1, // -1 for 0-index offset
         })
-      ).map((c) => {
+      ).map(c => {
         return {
           id: c,
           isOpen: false,
@@ -206,7 +206,7 @@ export default class CourseCardBrowser extends SkldrVue {
     const hydratedCardData = (
       await getCourseDocs<CardData>(
         this._id,
-        this.cards.map((c) => c.id.split('-')[1]),
+        this.cards.map(c => c.id.split('-')[1]),
         {
           include_docs: true,
         }
@@ -216,19 +216,19 @@ export default class CourseCardBrowser extends SkldrVue {
       this.cardData[c._id] = c.id_displayable_data;
     });
 
-    this.cards.forEach(async (c) => {
+    this.cards.forEach(async c => {
       // console.log(`generating preview for ${c}`);
       const _courseID: string = c.id.split('-')[0];
       const _cardID: string = c.id.split('-')[1];
 
-      const tmpCardData = hydratedCardData.find((c) => c._id == _cardID)!;
+      const tmpCardData = hydratedCardData.find(c => c._id == _cardID)!;
       // console.log(`tmpCardData: ${JSON.stringify(tmpCardData)}`);
       const tmpView = Courses.getView(tmpCardData.id_view || 'default.question.BlanksCard.FillInView');
 
       // todo 143 / perf: this fetch is non-blocking, but is making a db
       // query for each card. much much better to batch query by allDocs
       // with keys list
-      const tmpDataDocs = tmpCardData.id_displayable_data.map((id) => {
+      const tmpDataDocs = tmpCardData.id_displayable_data.map(id => {
         return getCourseDoc<DisplayableData>(_courseID, id, {
           attachments: false,
           binary: true,
@@ -237,7 +237,7 @@ export default class CourseCardBrowser extends SkldrVue {
 
       const allDocs = await Promise.all(tmpDataDocs);
       await Promise.all(
-        allDocs.map((doc) => {
+        allDocs.map(doc => {
           const tmpData = [];
           tmpData.unshift(displayableDataToViewData(doc));
 

--- a/packages/vue/src/components/Courses/TagInformation.vue
+++ b/packages/vue/src/components/Courses/TagInformation.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- todo: -->
-    <h1><router-link :to="`/q/${_courseId}`">[Course]</router-link> > Tag: {{ tag.name }}</h1>
+    <h1><router-link :to="`/q/${course.name}`">{{course.name}}</router-link> > Tag: {{ tag.name }}</h1>
     <br />
     <p>{{ tag.taggedCards.length }} card{{ tag.taggedCards.length === 1 ? '' : 's' }}</p>
 
@@ -60,9 +60,11 @@
 </template>
 
 <script lang="ts">
+import { getCredentialledCourseConfig } from '@/db/courseAPI';
 import { getTag, updateTag } from '@/db/courseDB';
 import { DocType, Tag } from '@/db/types';
 import { Status } from '@/enums/Status';
+import { CourseConfig } from '@/server/types';
 import SkldrVue from '@/SkldrVue';
 import { Component, Prop } from 'vue-property-decorator';
 import { alertUser } from '../SnackbarService.vue';
@@ -95,6 +97,20 @@ export default class TagInformation extends SkldrVue {
     wiki: '',
     taggedCards: [],
     docType: DocType.TAG,
+  };
+  public course: CourseConfig = {
+    courseID: this._courseId,
+    name: '',
+    description: '',
+    public: false,
+    deleted: false,
+
+    dataShapes: [],
+    questionTypes: [],
+
+    creator: '',
+    admins: [],
+    moderators: [],
   };
 
   public editSnippet() {
@@ -178,6 +194,7 @@ export default class TagInformation extends SkldrVue {
     this.tag = await getTag(this._courseId, this._id);
     this.snippetModel = this.tag.snippet;
     this.wikiModel = this.tag.wiki;
+    this.course = await getCredentialledCourseConfig(this._courseId);
   }
 }
 </script>


### PR DESCRIPTION
Against #205.

PR adds some robustness against `tag` lookups that return cards that no longer exist.