### PR TITLE
move to next card after game ends...

### DIFF
--- a/packages/vue/src/courses/typing/questions/falling-letters/FallingLetters.vue
+++ b/packages/vue/src/courses/typing/questions/falling-letters/FallingLetters.vue
@@ -82,6 +82,8 @@ export default class FallingLettersView extends QuestionView<FallingLettersQuest
     return new FallingLettersQuestion(this.data);
   }
 
+  maxAttemptsPerView = 1; // move on to next card after game is done
+
   treePositions: TreePosition[] = [];
 
   mounted() {


### PR DESCRIPTION
previously, the default behavior of 'waiting for a 2nd or 3rd attempt' was being run at the end of a losing game.