### PR TITLE
use relative paths...

### DIFF
--- a/packages/vue/src/base-course/Interfaces/FieldDefinition.ts
+++ b/packages/vue/src/base-course/Interfaces/FieldDefinition.ts
@@ -1,7 +1,7 @@
 import { Validator } from '../../base-course/Interfaces/Validator';
 import { Tagger } from '../../base-course/Interfaces/Tagger';
 import { FieldType } from '../../enums/FieldType';
-import { CourseElo } from '@/tutor/Elo';
+import { CourseElo } from '../../tutor/Elo';
 
 export interface FieldDefinition {
   name: string;

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInput.ts
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInput.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../base-course/Interfaces/ValidatingFunction';
 import { ValidationResult } from '../../../base-course/Interfaces/ValidationResult';
 import { Status } from '../../../enums/Status';
-import { CourseElo } from '@/tutor/Elo';
+import { CourseElo } from '../../../tutor/Elo';
 
 export interface ValidatedInput {
   getValidators: () => ValidatingFunction[];


### PR DESCRIPTION
required for the hacked build process of `express` app.

express imports from `vue` via relative paths, but does not
actually build the `vue` project. So child imports must also
allow for relative pathfinding of deps.
