### PR TITLE
use relative paths...

### DIFF
--- a/packages/vue/src/db/userDB.ts
+++ b/packages/vue/src/db/userDB.ts
@@ -17,7 +17,7 @@ import {
 } from './index';
 import UpdateQueue, { Update } from './updateQueue';
 import { CardHistory, CardRecord } from './types';
-import { PouchError } from '@/types/pouchdb';
+import { PouchError } from '../types/pouchdb';
 
 const cardHistoryPrefix = 'cardH-';
 const remoteStr: string = ENV.COUCHDB_SERVER_PROTOCOL + '://' + ENV.COUCHDB_SERVER_URL + 'skuilder';


### PR DESCRIPTION
required for the hacked build process of `express` app.

express imports from `vue` via relative paths, but does not
actually build the `vue` project. So child imports must also
allow for relative pathfinding of deps.
