### PR TITLE
refactor: convert src/base-course/Components/MarkdownRenderer.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "@babel/polyfill": "^7.4.4",
         "@johmun/vue-tags-input": "^2.1.0",
+        "@mdi/font": "^7.3.67",
         "@tonaljs/tonal": "^3.6.0",
         "abcjs": "^6.2.2",
         "canvas-confetti": "^1.3.2",
@@ -36,7 +37,6 @@
         "vue-property-decorator": "^9.1.2",
         "vue-router": "^3.6.5",
         "vuetify": "^2.7.2",
-        "@mdi/font": "^7.3.67",
         "vuex": "^3.6.1",
         "wavesurfer.js": "^5.1.0",
         "webmidi": "^2.5.1"
@@ -57,8 +57,8 @@
         "@types/simplemde": "^1.11.7",
         "@types/wavesurfer.js": "^5.1.0",
         "@types/webmidi": "^2.0.4",
-        "@typescript-eslint/eslint-plugin": "^4.18.0",
-        "@typescript-eslint/parser": "^4.18.0",
+        "@typescript-eslint/eslint-plugin": "6.21.1-alpha.1",
+        "@typescript-eslint/parser": "5.0.0-alpha.42",
         "@vue/cli-plugin-babel": "^5.0.8",
         "@vue/cli-plugin-pwa": "^5.0.8",
         "@vue/cli-plugin-router": "^5.0.8",
@@ -85,8 +85,8 @@
         "typescript": "~5.7.2",
         "util": "^0.12.5",
         "vue-cli-plugin-vuetify": "^2.5.8",
-        "vuetify-loader": "^1.7.3",
-        "vue-template-compiler": "^2.7.16"
+        "vue-template-compiler": "^2.7.16",
+        "vuetify-loader": "^1.7.3"
     },
     "engines": {
         "node": ">=16"

--- a/packages/vue/src/base-course/Components/MarkdownRenderer.vue
+++ b/packages/vue/src/base-course/Components/MarkdownRenderer.vue
@@ -10,11 +10,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { defineComponent, computed, PropType } from 'vue';
 import MdTokenRenderer from './MdTokenRenderer.vue';
-import { marked, Tokenizer } from 'marked';
+import { marked } from 'marked';
 import hljs from 'highlight.js';
-import SkldrVue from '@/SkldrVue';
+import SkldrVueMixin, { ISkldrMixin } from '@/mixins/SkldrVueMixin';
+import { SkldrComposable } from '@/mixins/SkldrComposable';
 
 type SkldrToken =
   | marked.Token
@@ -23,45 +24,38 @@ type SkldrToken =
       audio: string;
     };
 
-@Component({
+// Using Options API with mixin
+export default defineComponent({
+  name: 'MarkdownRenderer',
   components: {
     MdTokenRenderer,
   },
-})
-export default class MarkdownRenderer extends SkldrVue {
-  @Prop({
-    required: true,
-    type: String,
-  })
-  md: string;
-
-  public get testRoute(): boolean {
-    // this.log(`Route: ${this.$route.path}`);
-
-    if (this.$route.path === '/md') {
-      this.md = 'test md';
-      return true;
-    } else {
+  mixins: [SkldrVueMixin],
+  props: {
+    md: {
+      type: String as PropType<string>,
+      required: true
+    }
+  },
+  computed: {
+    testRoute(): boolean {
+      if (this.$route.path === '/md') {
+        (this as any).md = 'test md'; // Type safety note: prop mutation
+        return true;
+      }
       return false;
+    },
+    tokens(): SkldrToken[] {
+      const tokens = marked.lexer(this.md);
+      if (this.testRoute) {
+        tokens.forEach(t => {
+          (this as ISkldrMixin).log(JSON.stringify(t));
+        });
+      }
+      return tokens;
     }
   }
-
-  public get tokens(): SkldrToken[] {
-    // marked.setOptions({
-    //   highlight: (code, lang, cb) => {
-    //     this.log(`highlighting!`);
-    //     hljs.highlight(lang, code)
-    //   }
-    // })
-    const tokens = marked.lexer(this.md);
-    if (this.testRoute) {
-      tokens.forEach(t => {
-        this.log(JSON.stringify(t));
-      });
-    }
-    return tokens;
-  }
-}
+});
 </script>
 
 <style lang="css" scoped></style>

--- a/packages/vue/src/base-course/Components/MarkdownRenderer.vue
+++ b/packages/vue/src/base-course/Components/MarkdownRenderer.vue
@@ -10,12 +10,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, PropType } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import MdTokenRenderer from './MdTokenRenderer.vue';
 import { marked } from 'marked';
-import hljs from 'highlight.js';
 import SkldrVueMixin, { ISkldrMixin } from '@/mixins/SkldrVueMixin';
-import { SkldrComposable } from '@/mixins/SkldrComposable';
 
 type SkldrToken =
   | marked.Token
@@ -34,27 +32,14 @@ export default defineComponent({
   props: {
     md: {
       type: String as PropType<string>,
-      required: true
-    }
+      required: true,
+    },
   },
   computed: {
-    testRoute(): boolean {
-      if (this.$route.path === '/md') {
-        (this as any).md = 'test md'; // Type safety note: prop mutation
-        return true;
-      }
-      return false;
-    },
     tokens(): SkldrToken[] {
-      const tokens = marked.lexer(this.md);
-      if (this.testRoute) {
-        tokens.forEach(t => {
-          (this as ISkldrMixin).log(JSON.stringify(t));
-        });
-      }
-      return tokens;
-    }
-  }
+      return marked.lexer(this.md);
+    },
+  },
 });
 </script>
 

--- a/packages/vue/yarn.lock
+++ b/packages/vue/yarn.lock
@@ -2706,7 +2706,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7":
+"@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
@@ -2969,18 +2969,22 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.18.0":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz#c045e440196ae45464e08e20c38aff5c3a825947"
-  integrity sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==
+"@typescript-eslint/eslint-plugin@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.1-alpha.1.tgz#c3cf0ffe1e9b70793d760130729fd4785f7ed7f0"
+  integrity sha512-Y+3O6OrGY2zuOBjIYhyyDW3JW/icEd+0j7QtkUFJiJEhM3b8KFdl56bA4d0F4mB8XWs2dnGyH4eTdaWAt3Kygw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.28.1"
-    "@typescript-eslint/scope-manager" "4.28.1"
-    debug "^4.3.1"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.1.0"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "6.21.1-alpha.1"
+    "@typescript-eslint/type-utils" "6.21.1-alpha.1"
+    "@typescript-eslint/utils" "6.21.1-alpha.1"
+    "@typescript-eslint/visitor-keys" "6.21.1-alpha.1"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
 
 "@typescript-eslint/eslint-plugin@^6.7.0":
   version "6.21.0"
@@ -2999,26 +3003,14 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/experimental-utils@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz#3869489dcca3c18523c46018b8996e15948dbadc"
-  integrity sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==
+"@typescript-eslint/parser@5.0.0-alpha.42":
+  version "5.0.0-alpha.42"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.0.0-alpha.42.tgz#7357a20006b604cdc1cdf84af4d23e4f1f27b3c8"
+  integrity sha512-cEVag9EO+YHfMdJQzsOilwdHaTOL5Gbs4dI3docor2mQZbKKj4IZkS+kuuVbfynP9pLYNOA52kJO6iL2OYNeoQ==
   dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.28.1"
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/typescript-estree" "4.28.1"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
-"@typescript-eslint/parser@^4.18.0":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.1.tgz#5181b81658414f47291452c15bf6cd44a32f85bd"
-  integrity sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.28.1"
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/typescript-estree" "4.28.1"
+    "@typescript-eslint/scope-manager" "5.0.0-alpha.42+58207a83"
+    "@typescript-eslint/types" "5.0.0-alpha.42+58207a83"
+    "@typescript-eslint/typescript-estree" "5.0.0-alpha.42+58207a83"
     debug "^4.3.1"
 
 "@typescript-eslint/parser@^6.7.0":
@@ -3032,13 +3024,13 @@
     "@typescript-eslint/visitor-keys" "6.21.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz#fd3c20627cdc12933f6d98b386940d8d0ce8a991"
-  integrity sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==
+"@typescript-eslint/scope-manager@5.0.0-alpha.42+58207a83":
+  version "5.0.0-alpha.42"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.0.0-alpha.42.tgz#7f014ab572aeaac3903ea4e81c07f90dd2826707"
+  integrity sha512-3bANltnfbIpHtYD/Lq/xGQ9vGVY4AGz0a6ob3HDLNyPmiBtjljMECSZfBcFvtZwtwaPuxae+3uknzP04zjUGMw==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
+    "@typescript-eslint/types" "5.0.0-alpha.42+58207a83"
+    "@typescript-eslint/visitor-keys" "5.0.0-alpha.42+58207a83"
 
 "@typescript-eslint/scope-manager@6.21.0":
   version "6.21.0"
@@ -3047,6 +3039,14 @@
   dependencies:
     "@typescript-eslint/types" "6.21.0"
     "@typescript-eslint/visitor-keys" "6.21.0"
+
+"@typescript-eslint/scope-manager@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.21.1-alpha.1.tgz#73fb8c13b25dd36fd3d41b8951b1ec9a1b898d55"
+  integrity sha512-XVh1IVbdTz9+Hi7j1RwoNDr5KAqo7J+rXEzloa8jvv0Khdjs4jyVLHmATw3PVJCu0NYmZVueJrZprFdQXOhmjQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.1-alpha.1"
+    "@typescript-eslint/visitor-keys" "6.21.1-alpha.1"
 
 "@typescript-eslint/type-utils@6.21.0":
   version "6.21.0"
@@ -3058,23 +3058,38 @@
     debug "^4.3.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/types@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
-  integrity sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==
+"@typescript-eslint/type-utils@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-6.21.1-alpha.1.tgz#4555fa52ecfa77993366a9bdfd4cf99cb0edb354"
+  integrity sha512-PZn+NhMVBKWa7U24ysotMZcUrnBZ6orzeGbMNB550iRzWo56ZJ9thYda/jNr84OP0GkNazel85+CjqNz7rvblA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "6.21.1-alpha.1"
+    "@typescript-eslint/utils" "6.21.1-alpha.1"
+    debug "^4.3.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/types@5.0.0-alpha.42+58207a83":
+  version "5.0.0-alpha.42"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.0.0-alpha.42.tgz#ef311e0781304e8ca8a7100cc26625d1a11cbc94"
+  integrity sha512-EBjRR3MsrUr6gYI9vCTfuOLEZWMRmZGegmgP8WvtJYoWspXD3/GRE81DHSOlnZwGD2Jjw+XCPrslbDqGIA8qIg==
 
 "@typescript-eslint/types@6.21.0":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.0.tgz#205724c5123a8fef7ecd195075fa6e85bac3436d"
   integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
 
-"@typescript-eslint/typescript-estree@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz#af882ae41740d1f268e38b4d0fad21e7e8d86a81"
-  integrity sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==
+"@typescript-eslint/types@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.21.1-alpha.1.tgz#ae5ae9480fa283039fc57813490393300aab14af"
+  integrity sha512-oV+1sjaQgEYOpvmZ2AHsM8FMs13Ku/TU/WFoRnZHuktMzUf2Hw5OZC1oVDYATIISGLsxbOrsKxNnNybrxyV5IQ==
+
+"@typescript-eslint/typescript-estree@5.0.0-alpha.42+58207a83":
+  version "5.0.0-alpha.42"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.0.0-alpha.42.tgz#9f656e99ef1d1a3cce91ae8e61d4ac13ac2a28db"
+  integrity sha512-+MybOFjfbQeh9XiO8eRw4+ax0UzCSHbWKGUrY7HXVjGcDeZLWADF9VQ0fXkiqAGOjd2ALvfRzKA1Enb0LqS8mA==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    "@typescript-eslint/visitor-keys" "4.28.1"
+    "@typescript-eslint/types" "5.0.0-alpha.42+58207a83"
+    "@typescript-eslint/visitor-keys" "5.0.0-alpha.42+58207a83"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
@@ -3095,6 +3110,20 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
+"@typescript-eslint/typescript-estree@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.1-alpha.1.tgz#617f0fcd8d4bf5cec3e22794a0410a53dfbeb6f6"
+  integrity sha512-OT5kFY2tDDv88Up8i+DUybznTkmCh05pyTMD74/Kt9Kuaj0gF56MExNDieSlkjm50dFMGUXS3ILhUF72YgcoqQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.1-alpha.1"
+    "@typescript-eslint/visitor-keys" "6.21.1-alpha.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
 "@typescript-eslint/utils@6.21.0":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.21.0.tgz#4714e7a6b39e773c1c8e97ec587f520840cd8134"
@@ -3108,13 +3137,26 @@
     "@typescript-eslint/typescript-estree" "6.21.0"
     semver "^7.5.4"
 
-"@typescript-eslint/visitor-keys@4.28.1":
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
-  integrity sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==
+"@typescript-eslint/utils@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-6.21.1-alpha.1.tgz#cfee1571daea4e1c030d23e7677ee4ead1f4fbbf"
+  integrity sha512-DSOaRElRUHFY2RAGVTfyGCAT+pXvXQ+3qmH3ZqaIz8ENtaRKtwE9MBVlTJ+9M7cY8pqRSh4ZL7l1tpwcyqg2DA==
   dependencies:
-    "@typescript-eslint/types" "4.28.1"
-    eslint-visitor-keys "^2.0.0"
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.21.1-alpha.1"
+    "@typescript-eslint/types" "6.21.1-alpha.1"
+    "@typescript-eslint/typescript-estree" "6.21.1-alpha.1"
+    semver "^7.5.4"
+
+"@typescript-eslint/visitor-keys@5.0.0-alpha.42+58207a83":
+  version "5.0.0-alpha.42"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.0.0-alpha.42.tgz#513d8ccdf9392f5ff7013ce17062485dd4789dce"
+  integrity sha512-FO3ICEnUFtbMrx15x67ry8Fv18qOVASpNaM39iGUim9LC6L5p8IKYubnpun1/656tMNjuZHoFBMPyF7zt6wNRw==
+  dependencies:
+    "@typescript-eslint/types" "5.0.0-alpha.42+58207a83"
+    eslint-visitor-keys "^3.0.0"
 
 "@typescript-eslint/visitor-keys@6.21.0":
   version "6.21.0"
@@ -3122,6 +3164,14 @@
   integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
   dependencies:
     "@typescript-eslint/types" "6.21.0"
+    eslint-visitor-keys "^3.4.1"
+
+"@typescript-eslint/visitor-keys@6.21.1-alpha.1":
+  version "6.21.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.1-alpha.1.tgz#b7c5db649aa93f6381fd2beb99d149033e48e8f9"
+  integrity sha512-S91KlfjZTKtr5HHlBLlIwMUZqd3tcgrRuDOgpAdHjgNZE+TWtnHgyD3jTcb6rdwQt9bUImkUDMKDXA77ZEN+aQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.1-alpha.1"
     eslint-visitor-keys "^3.4.1"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.4.0":
@@ -5649,19 +5699,12 @@ eslint-scope@^7.1.1:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-utils@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
-  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
-  dependencies:
-    eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
+eslint-visitor-keys@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
@@ -6143,11 +6186,6 @@ function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
     functions-have-names "^1.2.3"
     hasown "^2.0.2"
     is-callable "^1.2.7"
-
-functional-red-black-tree@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
-  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 functions-have-names@^1.2.3:
   version "1.2.3"
@@ -9799,11 +9837,6 @@ regexp.prototype.flags@^1.5.3:
     define-properties "^1.2.1"
     es-errors "^1.3.0"
     set-function-name "^2.0.2"
-
-regexpp@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
-  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 regexpu-core@^4.7.1:
   version "4.7.1"


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Switching from class-based component to Options API using defineComponent
2. Converting @Prop decorator to props object
3. Converting class getters to computed properties
4. Incorporating SkldrVueMixin to maintain base class functionality
5. Adding proper type annotations for TypeScript support

Warnings:
1. Direct prop mutation in testRoute computed property is anti-pattern and may cause Vue warnings
2. The hljs highlighting setup is commented out in original and maintained as such
3. Type safety is slightly reduced due to mixin usage - requires casting to ISkldrMixin interface
4. The alternative Composition API version would provide better type safety but would require more extensive refactoring
