### PR TITLE
refactor: convert src/base-course/Components/MdTokenRenderer.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/base-course/Components/MdTokenRenderer.vue
+++ b/packages/vue/src/base-course/Components/MdTokenRenderer.vue
@@ -113,18 +113,20 @@ import {
   isComponent,
   splitParagraphToken,
   splitTextToken,
+  TokenOrComponent,
 } from '@/courses/default/questions/fillIn';
 import FillInInput from '@/courses/default/questions/fillIn/fillInInput.vue';
 import hljs from 'highlight.js';
 import { marked } from 'marked';
 import { defineComponent } from 'vue';
+import Vue from 'vue';
 import SkldrVueMixin from '@/mixins/SkldrVueMixin';
 
 Vue.use(hljs.vuePlugin);
 
 export default defineComponent({
   name: 'MdTokenRenderer',
-  
+
   components: {
     fillIn: FillInInput,
     RadioMultipleChoice,
@@ -135,13 +137,13 @@ export default defineComponent({
   props: {
     token: {
       type: Object as () => marked.Token,
-      required: true
+      required: true,
     },
     last: {
       type: Boolean,
       required: false,
-      default: false
-    }
+      default: false,
+    },
   },
 
   methods: {
@@ -157,7 +159,7 @@ export default defineComponent({
       return splitTextToken(token);
     },
 
-    splitParagraphToken(token: marked.Tokens.Paragraph): marked.Token[] {
+    splitParagraphToken(token: marked.Tokens.Paragraph): TokenOrComponent[] {
       return splitParagraphToken(token);
     },
 
@@ -173,8 +175,8 @@ export default defineComponent({
 
     isText(tok: marked.Token): tok is marked.Tokens.Text {
       return (tok as marked.Tokens.Tag).inLink === undefined && tok.type === 'text';
-    }
-  }
+    },
+  },
 });
 </script>
 

--- a/packages/vue/src/base-course/Components/MdTokenRenderer.vue
+++ b/packages/vue/src/base-course/Components/MdTokenRenderer.vue
@@ -48,13 +48,14 @@
         v-bind:last="last && token.tokens.length === 1 && j === splitParagraphToken(token).length - 1"
       />
     </span>
-    <md-token-renderer
-      v-for="(subTok, j) in token.tokens"
-      v-bind:key="j"
-      v-bind:token="subTok"
-      v-else
-      v-bind:last="last && token.tokens.length === 1"
-    />
+    <template v-else>
+      <md-token-renderer
+        v-for="(subTok, j) in token.tokens"
+        v-bind:key="j"
+        v-bind:token="subTok"
+        v-bind:last="last && token.tokens.length === 1"
+      />
+    </template>
   </p>
 
   <a v-else-if="token.type === 'link'" :href="token.href" :title="token.title">

--- a/packages/vue/src/base-course/Components/MdTokenRenderer.vue
+++ b/packages/vue/src/base-course/Components/MdTokenRenderer.vue
@@ -168,6 +168,18 @@ export default defineComponent({
       is: string;
       text: string;
     } {
+      // [ ] switching on component types & loading custom component
+      //
+      // sketch:
+      // const demoustached = token.text.slice(2, token.text.length - 2);
+      // const firstToken = demoustached.split(' ')[0];
+      // if (firstToken.charAt(firstToken.length - 1) == '>') {
+      //   return {
+      //     is: firstToken.slice(0, firstToken.length - 1),
+      //     text: demoustached.slice(firstToken.length + 1, demoustached.length),
+      //   };
+      // }
+
       return {
         is: 'fillIn',
         text: token.text,

--- a/packages/vue/src/base-course/Components/MdTokenRenderer.vue
+++ b/packages/vue/src/base-course/Components/MdTokenRenderer.vue
@@ -117,71 +117,65 @@ import {
 import FillInInput from '@/courses/default/questions/fillIn/fillInInput.vue';
 import hljs from 'highlight.js';
 import { marked } from 'marked';
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
+import SkldrVueMixin from '@/mixins/SkldrVueMixin';
 
 Vue.use(hljs.vuePlugin);
 
-@Component({
+export default defineComponent({
+  name: 'MdTokenRenderer',
+  
   components: {
     fillIn: FillInInput,
     RadioMultipleChoice,
   },
-})
-export default class MdTokenRenderer extends Vue {
-  @Prop({
-    required: true,
-    type: Object,
-  })
-  token: marked.Token;
-  @Prop({
-    required: false,
-    type: Boolean,
-    default: false,
-  })
-  last: boolean;
 
-  public isComponent(token: marked.Token) {
-    return isComponent(token);
-  }
-  public containsComponent(token: marked.Token) {
-    return containsComponent(token);
-  }
-  public splitTextToken(token: marked.Tokens.Text) {
-    return splitTextToken(token);
-  }
-  public splitParagraphToken(token: marked.Tokens.Paragraph) {
-    return splitParagraphToken(token);
-  }
+  mixins: [SkldrVueMixin],
 
-  public parsedComponent(
-    token: marked.Tokens.Text
-  ): {
-    is: string;
-    text: string;
-  } {
-    // todo: switching on component types & loading custom component
-    //
-    // sketch:
+  props: {
+    token: {
+      type: Object as () => marked.Token,
+      required: true
+    },
+    last: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
 
-    // const demoustached = token.text.slice(2, token.text.length - 2);
-    // const firstToken = demoustached.split(' ')[0];
-    // if (firstToken.charAt(firstToken.length - 1) == '>') {
-    //   return {
-    //     is: firstToken.slice(0, firstToken.length - 1),
-    //     text: demoustached.slice(firstToken.length + 1, demoustached.length),
-    //   };
-    // }
+  methods: {
+    isComponent(token: marked.Token): boolean {
+      return isComponent(token);
+    },
 
-    return {
-      is: 'fillIn',
-      text: token.text,
-    };
+    containsComponent(token: marked.Token): boolean {
+      return containsComponent(token);
+    },
+
+    splitTextToken(token: marked.Tokens.Text): marked.Token[] {
+      return splitTextToken(token);
+    },
+
+    splitParagraphToken(token: marked.Tokens.Paragraph): marked.Token[] {
+      return splitParagraphToken(token);
+    },
+
+    parsedComponent(token: marked.Tokens.Text): {
+      is: string;
+      text: string;
+    } {
+      return {
+        is: 'fillIn',
+        text: token.text,
+      };
+    },
+
+    isText(tok: marked.Token): tok is marked.Tokens.Text {
+      return (tok as marked.Tokens.Tag).inLink === undefined && tok.type === 'text';
+    }
   }
-
-  private isText(tok: marked.Token): tok is marked.Tokens.Text {
-    return (tok as marked.Tokens.Tag).inLink === undefined && tok.type === 'text';
-  }
-}
+});
 </script>
 
 <style lang="css" scoped>

--- a/packages/vue/src/courses/default/questions/fillIn/index.ts
+++ b/packages/vue/src/courses/default/questions/fillIn/index.ts
@@ -85,15 +85,9 @@ export function splitTextToken(token: marked.Tokens.Text): marked.Tokens.Text[] 
   }
 }
 
-export function splitParagraphToken(
-  token: marked.Tokens.Paragraph
-): (
-  | marked.Token
-  | {
-      type: 'component';
-      raw: string;
-    }
-)[] {
+export type TokenOrComponent = marked.Token | { type: 'component'; raw: string };
+
+export function splitParagraphToken(token: marked.Tokens.Paragraph): TokenOrComponent[] {
   let ret: marked.Token[] = [];
 
   if (containsComponent(token)) {
@@ -141,6 +135,8 @@ export function containsComponent(token: marked.Token) {
 
     if (opening !== -1 && closing !== -1 && closing > opening) {
       return true;
+    } else {
+      return false;
     }
   } else {
     return false;
@@ -242,9 +238,7 @@ export class BlanksCard extends Question {
     }
   }
 
-  findAnswers(
-    tok: marked.Token
-  ): {
+  findAnswers(tok: marked.Token): {
     answers: string[] | null;
     options: string[] | null;
   } | null {
@@ -303,7 +297,7 @@ export class BlanksCard extends Question {
 
   constructor(data: ViewData[]) {
     super(data);
-    this.mdText = (data[0].Input as any) as string;
+    this.mdText = data[0].Input as any as string;
 
     const splits = splitByDelimiters(this.mdText, '{{', '}}');
     const recombines = [];


### PR DESCRIPTION
Summary:
This conversion moves from the Class API to Options API format. The main changes include:
1. Converting @Component decorator to defineComponent
2. Moving props from decorators to props object
3. Converting class methods to methods object
4. Adding SkldrVueMixin to maintain base functionality
5. Maintaining TypeScript type safety through type annotations

Warnings:
1. The component previously extended Vue directly which gave direct access to Vue instance features. Now it relies on the SkldrVueMixin for those features.
2. Type safety is maintained but the structure is slightly different - props are typed through runtime validators rather than decorators.
3. The mixin approach might cause naming conflicts if other mixins are added that have methods with the same names.
4. If this component is referenced by other components expecting a class instance, those references may need updating.
