### PR TITLE
refactor: convert src/base-course/Components/RadioMultipleChoice.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/base-course/Components/RadioMultipleChoice.vue
+++ b/packages/vue/src/base-course/Components/RadioMultipleChoice.vue
@@ -14,98 +14,116 @@
 </template>
 
 <script lang="ts">
-import UserInput from '@/base-course/Components/UserInput/UserInput';
-import { Component, Prop } from 'vue-property-decorator';
+import { defineComponent, ref, onMounted, onBeforeMount, PropType } from 'vue';
+import { SkldrComposable } from '@/mixins/SkldrComposable';
 import MultipleChoiceOption from './MultipleChoiceOption.vue';
 import { Answer } from '../Displayable';
+import { useStore } from 'vuex';
 
 export interface RadioSelectAnswer extends Answer {
   choiceList: string[];
   selection: number;
 }
 
-@Component({
+export default defineComponent({
+  name: 'RadioSelect',
+  
   components: {
     MultipleChoiceOption,
   },
-})
-export default class RadioSelect extends UserInput {
-  @Prop({
-    required: true,
-  })
-  public choiceList: string[];
-  @Prop() public MouseTrap: any;
 
-  public currentSelection: number = -1;
-  public incorrectSelections: number[] = [];
+  props: {
+    choiceList: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+    MouseTrap: {
+      type: Object,
+      required: false,
+    },
+  },
 
-  public mounted() {
-    this.$el.focus();
-  }
+  setup(props, { emit }) {
+    const { log, error, warn } = SkldrComposable();
+    const store = useStore();
+    
+    const currentSelection = ref(-1);
+    const incorrectSelections = ref<number[]>([]);
 
-  public created() {
-    this.MouseTrap.bind('left', this.decrementSelection);
-    this.MouseTrap.bind('right', this.incrementSelection);
-    this.MouseTrap.bind('enter', this.forwardSelection);
-
-    for (let i = 0; i < this.choiceList.length; i++) {
-      this.bindNumberKey(i + 1);
-    }
-  }
-
-  public forwardSelection(): void {
-    if (this.choiceIsWrong(this.choiceList[this.currentSelection])) {
-      return; // do not 'resubmit' greyed-out choices
-    } else if (this.currentSelection !== -1) {
-      const ans: RadioSelectAnswer = {
-        choiceList: this.choiceList,
-        selection: this.currentSelection,
-      };
-      const record = this.submitAnswer(ans);
-
-      if (!record.isCorrect) {
-        this.incorrectSelections.push(this.currentSelection);
+    const setSelection = (selection: number): void => {
+      if (selection < props.choiceList.length) {
+        currentSelection.value = selection;
       }
-    }
-  }
+    };
 
-  public setSelection(selection: number): void {
-    if (selection < this.choiceList.length) {
-      this.currentSelection = selection;
-    }
-  }
+    const incrementSelection = () => {
+      if (currentSelection.value === -1) {
+        currentSelection.value = Math.ceil(props.choiceList.length / 2);
+      } else {
+        currentSelection.value = Math.min(props.choiceList.length - 1, currentSelection.value + 1);
+      }
+    };
 
-  public incrementSelection() {
-    // alert('increment');
-    if (this.currentSelection === -1) {
-      this.currentSelection = Math.ceil(this.choiceList.length / 2);
-    } else {
-      this.currentSelection = Math.min(this.choiceList.length - 1, this.currentSelection + 1);
-    }
-  }
+    const decrementSelection = () => {
+      if (currentSelection.value === -1) {
+        currentSelection.value = Math.floor(props.choiceList.length / 2 - 1);
+      } else {
+        currentSelection.value = Math.max(0, currentSelection.value - 1);
+      }
+    };
 
-  public decrementSelection() {
-    if (this.currentSelection === -1) {
-      this.currentSelection = Math.floor(this.choiceList.length / 2 - 1);
-    } else {
-      this.currentSelection = Math.max(0, this.currentSelection - 1);
-    }
-  }
+    const choiceIsWrong = (choice: string): boolean => {
+      let ret = false;
+      incorrectSelections.value.forEach((sel) => {
+        if (props.choiceList[sel] === choice) {
+          ret = true;
+        }
+      });
+      return ret;
+    };
 
-  public choiceIsWrong(choice: string): boolean {
-    let ret: boolean = false;
-    this.incorrectSelections.forEach((sel) => {
-      if (this.choiceList[sel] === choice) {
-        ret = true;
+    const bindNumberKey = (n: number): void => {
+      props.MouseTrap?.bind(n.toString(), () => {
+        currentSelection.value = n - 1;
+      });
+    };
+
+    const forwardSelection = (): void => {
+      if (choiceIsWrong(props.choiceList[currentSelection.value])) {
+        return;
+      } else if (currentSelection.value !== -1) {
+        const ans: RadioSelectAnswer = {
+          choiceList: props.choiceList,
+          selection: currentSelection.value,
+        };
+        // Note: This needs to be handled differently as UserInput base class functionality
+        emit('submit-answer', ans);
+      }
+    };
+
+    onMounted(() => {
+      // Focus functionality from mounted hook
+      const el = document.querySelector('.multipleChoice');
+      el?.focus();
+    });
+
+    onBeforeMount(() => {
+      props.MouseTrap?.bind('left', decrementSelection);
+      props.MouseTrap?.bind('right', incrementSelection);
+      props.MouseTrap?.bind('enter', forwardSelection);
+
+      for (let i = 0; i < props.choiceList.length; i++) {
+        bindNumberKey(i + 1);
       }
     });
-    return ret;
-  }
 
-  private bindNumberKey(n: number): void {
-    this.MouseTrap.bind(n.toString(), () => {
-      this.currentSelection = n - 1;
-    });
-  }
-}
+    return {
+      currentSelection,
+      incorrectSelections,
+      setSelection,
+      forwardSelection,
+      choiceIsWrong,
+    };
+  },
+});
 </script>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Switching from class-based to Composition API structure
2. Converting class properties to refs
3. Moving lifecycle hooks to onMounted/onBeforeMount
4. Converting methods to regular functions within setup()
5. Using SkldrComposable instead of base class functionality
6. Properly typing props using PropType
7. Moving component registration to components option

Warnings:
1. The component originally extended UserInput base class. The submitAnswer method from this base class needs to be handled differently - currently emitting an event instead.
2. Type safety for the MouseTrap prop might need improvement depending on the actual type of the MouseTrap library
3. Focus functionality might need adjustment depending on how UserInput base class handled it
4. Additional event handling or base class functionality might need to be implemented if UserInput provided more features
5. The SkldrComposable utilities (log, error, warn) are imported but may need to be used more extensively depending on the full base class functionality
6. The store functionality from SkldrVue base class needs to be explicitly imported using useStore if needed
