### PR TITLE
refactor: convert src/base-course/Components/UserInput/UserInputNumber.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/base-course/Components/UserInput/UserInputNumber.vue
+++ b/packages/vue/src/base-course/Components/UserInput/UserInputNumber.vue
@@ -18,19 +18,32 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
-import UserInput from './UserInput';
+// Composition API Version
+import { onMounted, getCurrentInstance } from 'vue';
+import { SkldrComposable } from '@/mixins/SkldrComposable';
+import type { UserInput } from './UserInput';
 
-@Component({})
-export default class UserInputNumber extends UserInput {
-  public mounted() {
-    this.$el.focus();
-  }
+// Get skldr utilities
+const { log, error, warn } = SkldrComposable();
 
-  private strToNumber(num: string): number {
-    return Number.parseFloat(num);
-  }
-}
+// Props should match those from UserInput base class
+defineProps<{
+  autofocus?: boolean,
+  answer: string
+}>();
+
+// Emits should match those from UserInput base class
+defineEmits<{
+  (e: 'submit', value: number): void
+}>();
+
+const strToNumber = (num: string): number => {
+  return Number.parseFloat(num);
+};
+
+onMounted(() => {
+  getCurrentInstance()?.proxy?.$el.focus();
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Removing the class-based structure and @Component decorator
2. Using composition API with  syntax
3. Converting the base class inheritance to composable utilities
4. Explicitly defining props and emits that were inherited from UserInput
5. Converting class methods to const functions
6. Using onMounted hook instead of class lifecycle method

Warnings:
1. The base class inheritance (UserInput) functionality needs to be replicated - props and events from the parent class need to be explicitly defined
2. Type safety from class inheritance is lost and needs manual type declarations
3. The  focus() call in mounted() might need adjustment depending on Vue 3 migration
4. The v-text-field component from Vuetify 2 might need updates for Vuetify 3 compatibility
5. The SkldrComposable utilities (log, error, warn) replace the base class methods but may need additional configuration
6. Need to verify all props and emits from UserInput base class are properly declared
