### PR TITLE
refactor: convert src/components/Courses/CourseStubCard.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Courses/CourseStubCard.vue
+++ b/packages/vue/src/components/Courses/CourseStubCard.vue
@@ -20,27 +20,34 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { log } from 'util';
-import Component from 'vue-class-component';
-import { Prop } from 'vue-property-decorator';
-import Vue from 'vue';
 import { getCourseDB } from '@/db';
 import { getCourseConfig } from '@/db/courseDB';
 import { DocType } from '@/db/types';
 import { CourseConfig } from '@/server/types';
 
-@Component({})
-export default class CourseStubCard extends Vue {
-  @Prop({ required: true }) private _id: string;
+export default defineComponent({
+  name: 'CourseStubCard',
+  
+  props: {
+    _id: {
+      type: String,
+      required: true
+    }
+  },
 
-  public _courseConfig: CourseConfig;
-  public questionCount: number;
-  public isPrivate: boolean = false;
+  data() {
+    return {
+      _courseConfig: null as CourseConfig | null,
+      questionCount: 0,
+      isPrivate: false,
+      updatePending: true,
+      addingCourse: false
+    };
+  },
 
-  private updatePending: boolean = true;
-  private addingCourse: boolean = false;
-
-  private async created() {
+  async created() {
     const db = await getCourseDB(this._id);
     this._courseConfig = (await getCourseConfig(this._id))!;
     this.isPrivate = !this._courseConfig.public;
@@ -53,19 +60,19 @@ export default class CourseStubCard extends Vue {
       })
     ).docs.length;
     this.updatePending = false;
-  }
+  },
 
-  routeToCourse() {
-    this.$router.push(`/q/${this._courseConfig.name.replace(' ', '_')}`);
-  }
+  methods: {
+    routeToCourse() {
+      this.$router.push(`/q/${this._courseConfig!.name.replace(' ', '_')}`);
+    },
 
-  async registerForCourse() {
-    this.addingCourse = true;
-    log(`Attempting to register for ${this._id}.`);
-    await this.$store.state._user!.registerForCourse(this._id);
-    // this.$set(this.spinnerMap, course, undefined);
-    // this.refreshData();
-    this.$emit('refresh');
+    async registerForCourse() {
+      this.addingCourse = true;
+      log(`Attempting to register for ${this._id}.`);
+      await this.$store.state._user!.registerForCourse(this._id);
+      this.$emit('refresh');
+    }
   }
-}
+});
 </script>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Replacing the class-based structure with defineComponent()
2. Moving @Prop decorator to props object
3. Moving class properties to data()
4. Moving methods to methods object
5. Maintaining TypeScript type annotations where possible
6. Added non-null assertions (!) where TypeScript needed extra hints

Warnings:
Some TypeScript type safety may be reduced in the following areas:
1. The _courseConfig initialization as null in data() is not ideal but necessary due to how Vue 2 data works
2. Store typing (_user property) might need additional type guards depending on your store setup
3. The non-null assertions (!) are a bit more prominent in the Options API version
