### PR TITLE
refactor: convert src/components/Edit/CardBrowser.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/CardBrowser.vue
+++ b/packages/vue/src/components/Edit/CardBrowser.vue
@@ -18,39 +18,59 @@
 import { ViewData } from '@/base-course/Interfaces/ViewData';
 import Viewable from '@/base-course/Viewable';
 import CardViewer from '@/components/Study/CardViewer.vue';
-import Vue from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { VueConstructor } from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
 
-@Component({
+export default defineComponent({
+  name: 'CardBrowser',
+  
   components: {
     CardViewer,
   },
-})
-export default class CardBrowser extends Vue {
-  @Prop() public views: Array<VueConstructor<Viewable>>;
-  @Prop() public data: ViewData[];
-  public viewIndex: number = 0;
-  public get spinner(): boolean {
-    return this.views.length > 1;
-  }
 
-  private created() {
+  props: {
+    views: {
+      type: Array as PropType<Array<VueConstructor<Viewable>>>,
+      required: true
+    },
+    data: {
+      type: Array as PropType<ViewData[]>,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      viewIndex: 0
+    }
+  },
+
+  computed: {
+    spinner(): boolean {
+      return this.views.length > 1;
+    }
+  },
+
+  created() {
     console.log(`[CardBrowser] Card browser created. Cards now in 'prewviewMode'`);
     this.$store.state.cardPreviewMode = true;
-  }
-  private destroyed() {
+  },
+
+  destroyed() {
     console.log(`[CardBrowser] Card browser destroyed. Cards no longer in 'prewviewMode'`);
     this.$store.state.cardPreviewMode = false;
-  }
+  },
 
-  private incrementView() {
-    this.viewIndex++;
-    this.viewIndex = (this.viewIndex + this.views.length) % this.views.length;
+  methods: {
+    incrementView() {
+      this.viewIndex++;
+      this.viewIndex = (this.viewIndex + this.views.length) % this.views.length;
+    },
+    
+    decrementView() {
+      this.viewIndex--;
+      this.viewIndex = (this.viewIndex + this.views.length) % this.views.length;
+    }
   }
-  private decrementView() {
-    this.viewIndex--;
-    this.viewIndex = (this.viewIndex + this.views.length) % this.views.length;
-  }
-}
+});
 </script>

--- a/packages/vue/src/components/Edit/CardBrowser.vue
+++ b/packages/vue/src/components/Edit/CardBrowser.vue
@@ -23,7 +23,7 @@ import { VueConstructor } from 'vue';
 
 export default defineComponent({
   name: 'CardBrowser',
-  
+
   components: {
     CardViewer,
   },
@@ -31,24 +31,24 @@ export default defineComponent({
   props: {
     views: {
       type: Array as PropType<Array<VueConstructor<Viewable>>>,
-      required: true
+      required: true,
     },
     data: {
       type: Array as PropType<ViewData[]>,
-      required: true
-    }
+      required: true,
+    },
   },
 
   data() {
     return {
-      viewIndex: 0
-    }
+      viewIndex: 0,
+    };
   },
 
   computed: {
     spinner(): boolean {
       return this.views.length > 1;
-    }
+    },
   },
 
   created() {
@@ -66,11 +66,11 @@ export default defineComponent({
       this.viewIndex++;
       this.viewIndex = (this.viewIndex + this.views.length) % this.views.length;
     },
-    
+
     decrementView() {
       this.viewIndex--;
       this.viewIndex = (this.viewIndex + this.views.length) % this.views.length;
-    }
-  }
+    },
+  },
 });
 </script>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Replacing the class-based structure with defineComponent()
2. Converting @Prop decorators to a props object with proper typing using PropType
3. Moving class properties to data()
4. Converting class methods to the methods object
5. Moving computed properties to the computed object
6. Converting lifecycle hooks to their Options API equivalents
7. Maintaining TypeScript type safety through PropType and return type annotations

Warnings:
No significant issues or loss of functionality are expected in this conversion as this component:
- Does not extend any base class
- Uses standard Vue lifecycle hooks
- Has straightforward prop and data management
- Maintains all original type safety through PropType
