### PR TITLE
refactor: convert src/components/Edit/ComponentRegistration/UnregisteredComponentsTable.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/ComponentRegistration/UnregisteredComponentsTable.vue
+++ b/packages/vue/src/components/Edit/ComponentRegistration/UnregisteredComponentsTable.vue
@@ -11,6 +11,8 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 
+// [ ] delete this file
+
 export default defineComponent({
   name: 'UnregisteredComponentsTable',
 });

--- a/packages/vue/src/components/Edit/ComponentRegistration/UnregisteredComponentsTable.vue
+++ b/packages/vue/src/components/Edit/ComponentRegistration/UnregisteredComponentsTable.vue
@@ -9,6 +9,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'UnregisteredComponentsTable',
+});
 </script>


### PR DESCRIPTION
Summary:
This was a very basic conversion since the original component was essentially empty except for the Vue and decorator imports. The conversion simply:
1. Removed the class-based syntax imports
2. Switched to  for better TypeScript support
3. Added an explicit component name

Warnings:
(none)
