### PR TITLE
refactor: convert src/components/Edit/DataTable/DataShapeTableHeader.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/DataTable/DataShapeTableHeader.vue
+++ b/packages/vue/src/components/Edit/DataTable/DataShapeTableHeader.vue
@@ -7,16 +7,20 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 import { DataShape } from '@/base-course/Interfaces/DataShape';
 // import Courses from '@/courses';
 // import DataInputForm from './ViewableDataInputForm/DataInputForm.vue';
 
-@Component
-export default class DataShapeTableHeader extends Vue {
-  @Prop() private dataShape: DataShape;
-}
+export default defineComponent({
+  name: 'DataShapeTableHeader',
+  props: {
+    dataShape: {
+      type: Object as PropType<DataShape>,
+      required: true
+    }
+  }
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
The conversion process was straightforward for this simple component:
1. Removed Vue class-based decorators (@Component, @Prop)
2. Switched to defineComponent() for better TypeScript support
3. Converted the class-style prop to Options API props object
4. Added PropType for proper TypeScript type safety on the prop
5. Retained existing system design comments
6. Added component name which was implicit in the class name before

Warnings:
(none)
