### PR TITLE
refactor: convert src/components/Edit/DataTable/DataShapeTableRow.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/DataTable/DataShapeTableRow.vue
+++ b/packages/vue/src/components/Edit/DataTable/DataShapeTableRow.vue
@@ -7,15 +7,22 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 import { DataShape } from '@/base-course/Interfaces/DataShape';
 
-@Component
-export default class DataShapeTableRows extends Vue {
-  @Prop() private dataShape: DataShape;
-  @Prop() private data: {};
-}
+export default defineComponent({
+  name: 'DataShapeTableRows',
+  props: {
+    dataShape: {
+      type: Object as PropType<DataShape>,
+      required: true
+    },
+    data: {
+      type: Object as PropType<Record<string, unknown>>,
+      required: true,
+    }
+  }
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
The conversion process was straightforward for this simple component:
1. Removed class-based decorators and infrastructure
2. Switched to defineComponent() with Options API
3. Converted @Prop decorators to props option object
4. Added explicit typing for props using PropType
5. Improved type safety by using Record<string, unknown> for the data prop instead of empty object type

Warnings:
No issues with base class functionality as this component doesn't extend any base classes and has minimal functionality.
