### PR TITLE
refactor: convert src/components/Edit/ViewableDataInputForm/FieldInputs/ChessPuzzleInput.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/ChessPuzzleInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/ChessPuzzleInput.vue
@@ -12,58 +12,53 @@
 </template>
 
 <script lang="ts">
-import { Component, Watch } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { FieldInput } from '../FieldInput';
 import { toCourseElo, CourseElo } from '@/tutor/Elo';
 
-@Component
-export default class ChessPuzzleInput extends FieldInput {
-  /*
-  From https://database.lichess.org/#puzzles
+export default defineComponent({
+  name: 'ChessPuzzleInput',
+  extends: FieldInput,
 
-  Puzzles are formatted as standard CSV. The fields are as follows:
-
-  PuzzleId,FEN,Moves,Rating,RatingDeviation,Popularity,NbPlays,Themes,GameUrl,OpeningTags
-
-  */
-
-  public mounted() {
+  mounted() {
     this.validate();
-  }
+  },
 
-  public generateELO() {
-    const split = (this.store[this.field.name] as string).split(',');
-    const elo = parseInt(split[3]);
-    const count = parseInt(split[6]);
+  methods: {
+    generateELO(): CourseElo {
+      const split = (this.store[this.field.name] as string).split(',');
+      const elo = parseInt(split[3]);
+      const count = parseInt(split[6]);
 
-    let crsElo: CourseElo = {
-      global: {
-        score: elo,
-        count,
-      },
-      tags: {},
-      misc: {},
-    };
-
-    const tags = this.generateTags();
-    tags.forEach((t) => {
-      crsElo.tags[t] = {
-        score: elo,
-        count,
+      let crsElo: CourseElo = {
+        global: {
+          score: elo,
+          count,
+        },
+        tags: {},
+        misc: {},
       };
-    });
 
-    console.log('generateELO', JSON.stringify(crsElo));
+      const tags = this.generateTags();
+      tags.forEach((t) => {
+        crsElo.tags[t] = {
+          score: elo,
+          count,
+        };
+      });
 
-    return crsElo;
+      console.log('generateELO', JSON.stringify(crsElo));
+
+      return crsElo;
+    },
+
+    generateTags(): string[] {
+      const split = (this.store[this.field.name] as string).split(',');
+      const themes = split[7].split(' ');
+      const openingTags = split[9].split(' ');
+
+      return themes.map((t) => `theme-${t}`).concat(openingTags.map((t) => `opening-${t}`));
+    }
   }
-
-  public generateTags() {
-    const split = (this.store[this.field.name] as string).split(',');
-    const themes = split[7].split(' ');
-    const openingTags = split[9].split(' ');
-
-    return themes.map((t) => `theme-${t}`).concat(openingTags.map((t) => `opening-${t}`));
-  };
-}
+});
 </script>

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/ChessPuzzleInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/ChessPuzzleInput.vue
@@ -12,13 +12,30 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import { FieldInput } from '../FieldInput';
+import { defineComponent, PropType } from 'vue';
+import FieldInput from '../OptionsFieldInput';
 import { toCourseElo, CourseElo } from '@/tutor/Elo';
+import { FieldDefinition } from '../../../../base-course/Interfaces/FieldDefinition';
 
 export default defineComponent({
   name: 'ChessPuzzleInput',
   extends: FieldInput,
+
+  props: {
+    field: {
+      type: Object as PropType<FieldDefinition>,
+      required: true,
+    },
+    store: {
+      type: Object as PropType<any>,
+      required: true,
+    },
+    uiValidationFunction: {
+      type: Function as PropType<() => boolean>,
+      required: true,
+    },
+    autofocus: Boolean,
+  },
 
   mounted() {
     this.validate();
@@ -58,7 +75,7 @@ export default defineComponent({
       const openingTags = split[9].split(' ');
 
       return themes.map((t) => `theme-${t}`).concat(openingTags.map((t) => `opening-${t}`));
-    }
-  }
+    },
+  },
 });
 </script>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Removing the class decorator and property-decorator imports
2. Using defineComponent instead of the class syntax
3. Converting class methods to the methods object
4. Extending from FieldInput using the extends option
5. Maintaining TypeScript types for methods and return values

Warnings:
Since this component extends FieldInput, make sure that:
1. The FieldInput base component has also been converted to Options API, or
2. There is proper inheritance compatibility between class-based and Options API components in your Vue 2.7 setup.
The exact behavior might depend on how FieldInput is implemented and how it manages its state and methods.
