### PR TITLE
refactor: convert src/components/Edit/ViewableDataInputForm/FieldInputs/MarkdownInput.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MarkdownInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MarkdownInput.vue
@@ -11,19 +11,21 @@
 </template>
 
 <script lang="ts">
-import { Component } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { FieldInput } from '../FieldInput';
 import SimpleMDE from 'simplemde';
 
-@Component
-export default class MarkdownInput extends FieldInput {
-  public get validators() {
-    const ret = super.validators;
-    return ret;
-  }
-
-  public mounted() {}
-}
+export default defineComponent({
+  name: 'MarkdownInput',
+  extends: FieldInput,
+  computed: {
+    validators() {
+      const ret = FieldInput.prototype.validators;
+      return ret;
+    }
+  },
+  mounted() {}
+});
 </script>
 
 <style scoped>

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MarkdownInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MarkdownInput.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { FieldInput } from '../FieldInput';
+import FieldInput from '../OptionsFieldInput';
 import SimpleMDE from 'simplemde';
 
 export default defineComponent({
@@ -20,11 +20,11 @@ export default defineComponent({
   extends: FieldInput,
   computed: {
     validators() {
-      const ret = FieldInput.prototype.validators;
+      const ret = FieldInput.computed?.validators;
       return ret;
-    }
+    },
   },
-  mounted() {}
+  mounted() {},
 });
 </script>
 


### PR DESCRIPTION
Summary:
The conversion process was straightforward for this component as it's relatively simple. The key changes were:
1. Removing Vue Property Decorator imports and @Component decorator
2. Using defineComponent for better TypeScript support
3. Converting the class syntax to Options API
4. Preserving inheritance by using 'extends' with FieldInput
5. Moving the getter to computed property
6. Keeping the empty mounted hook for future implementation

Warnings:
1. The access to base class validators through FieldInput.prototype.validators might not have exactly the same behavior as the class-based super.validators. You may need to verify this works as expected in your specific implementation.
2. Depending on how FieldInput is implemented, some TypeScript type information might be lost in the conversion from class-based to Options API. This is particularly true for complex inheritance chains.
