### PR TITLE
refactor: convert src/components/Edit/ViewableDataInputForm/FieldInputs/MediaUploader.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/ViewableDataInputForm/DataInputForm.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/DataInputForm.vue
@@ -118,7 +118,6 @@ import ImageInput from './FieldInputs/ImageInput.vue';
 import IntegerInput from './FieldInputs/IntegerInput.vue';
 import MarkdownInput from './FieldInputs/MarkdownInput.vue';
 import MediaDragDropUploader from './FieldInputs/MediaDragDropUploader.vue';
-import MediaUploader from './FieldInputs/MediaUploader.vue';
 import MidiInput from './FieldInputs/MidiInput.vue';
 import NumberInput from './FieldInputs/NumberInput.vue';
 import StringInput from './FieldInputs/StringInput.vue';
@@ -137,7 +136,6 @@ type StringIndexable = { [x: string]: any };
     MarkdownInput,
     MidiInput,
     CardBrowser,
-    MediaUploader,
     MediaDragDropUploader,
     TagsInput,
     ChessPuzzleInput,

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MediaUploader.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MediaUploader.vue
@@ -33,11 +33,11 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { FieldDefinition } from '@/base-course/Interfaces/FieldDefinition';
 import { ValidatingFunction } from '@/base-course/Interfaces/ValidatingFunction';
 import { FieldType } from '@/enums/FieldType';
 import { Status } from '@/enums/Status';
-import { Component } from 'vue-property-decorator';
 import WaveSurfer from 'wavesurfer.js';
 import { FieldInput } from '../FieldInput';
 import AudioInput from './AudioInput.vue';
@@ -49,62 +49,63 @@ type MediaData = {
   fieldDef: FieldDefinition;
 };
 
-@Component({
+export default defineComponent({
+  name: 'MediaUploadInput',
   components: {
     AudioInput,
     ImageInput,
   },
-})
-export default class MediaUploadInput extends FieldInput {
-  public get title(): string {
-    return this.field.name;
-  }
-  public clearData() {
-    this.audio = [];
-    this.image = [];
-  }
-
-  public audio: MediaData[] = [];
-  public image: MediaData[] = [];
-
-  private mediaRecorder: any;
-  private wavesurfer: WaveSurfer;
-
-  newImage() {
-    const name = `image-${this.image.length + 1}`;
-    this.store[name] = {};
-    this.image.push({
-      data: new Blob(),
-      fieldDef: {
-        name,
-        type: FieldType.IMAGE,
-      },
-    });
-  }
-
-  newAudio() {
-    const name = `audio-${this.audio.length + 1}`;
-    this.store[name] = {};
-    this.audio.push({
-      data: new Blob(),
-      fieldDef: {
-        name,
-        type: FieldType.AUDIO,
-      },
-    });
-    this.field;
-  }
-  public getValidators(): ValidatingFunction[] {
-    return [
-      () => {
-        return {
+  extends: FieldInput,
+  data() {
+    return {
+      audio: [] as MediaData[],
+      image: [] as MediaData[],
+      mediaRecorder: null as any,
+      wavesurfer: null as WaveSurfer | null
+    };
+  },
+  computed: {
+    title(): string {
+      return this.field.name;
+    }
+  },
+  methods: {
+    clearData(): void {
+      this.audio = [];
+      this.image = [];
+    },
+    newImage(): void {
+      const name = `image-${this.image.length + 1}`;
+      this.store[name] = {};
+      this.image.push({
+        data: new Blob(),
+        fieldDef: {
+          name,
+          type: FieldType.IMAGE,
+        },
+      });
+    },
+    newAudio(): void {
+      const name = `audio-${this.audio.length + 1}`;
+      this.store[name] = {};
+      this.audio.push({
+        data: new Blob(),
+        fieldDef: {
+          name,
+          type: FieldType.AUDIO,
+        },
+      });
+    },
+    getValidators(): ValidatingFunction[] {
+      return [
+        () => ({
           status: Status.ok,
           msg: '',
-        };
-      },
-    ];
+        }),
+      ];
+    }
   }
-}
+});
 </script>
 
 <style scoped>

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MediaUploader.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/MediaUploader.vue
@@ -16,7 +16,7 @@
       v-bind:uiValidationFunction="uiValidationFunction"
       v-for="(a, i) in audio"
       :autofocus="false"
-      v-bind:key="'audio'+i"
+      v-bind:key="'audio' + i"
       v-bind:field="a.fieldDef"
       v-bind:store="store"
     ></audio-input>
@@ -25,7 +25,7 @@
       v-bind:uiValidationFunction="uiValidationFunction"
       v-for="(img, i) in image"
       :autofocus="false"
-      v-bind:key="'image'+i"
+      v-bind:key="'image' + i"
       v-bind:field="img.fieldDef"
       v-bind:store="store"
     ></image-input>
@@ -39,7 +39,7 @@ import { ValidatingFunction } from '@/base-course/Interfaces/ValidatingFunction'
 import { FieldType } from '@/enums/FieldType';
 import { Status } from '@/enums/Status';
 import WaveSurfer from 'wavesurfer.js';
-import { FieldInput } from '../FieldInput';
+import FieldInput from '../OptionsFieldInput';
 import AudioInput from './AudioInput.vue';
 import ImageInput from './ImageInput.vue';
 var MediaStreamRecorder = require('msr');
@@ -61,13 +61,13 @@ export default defineComponent({
       audio: [] as MediaData[],
       image: [] as MediaData[],
       mediaRecorder: null as any,
-      wavesurfer: null as WaveSurfer | null
+      wavesurfer: null as WaveSurfer | null,
     };
   },
   computed: {
     title(): string {
       return this.field.name;
-    }
+    },
   },
   methods: {
     clearData(): void {
@@ -103,8 +103,8 @@ export default defineComponent({
           msg: '',
         }),
       ];
-    }
-  }
+    },
+  },
 });
 </script>
 


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Switching from class-based decorator syntax to Options API using defineComponent
2. Moving class properties to data() return object
3. Converting class methods to the methods object
4. Converting getter to computed property
5. Maintaining the extension of FieldInput base component using extends
6. Preserving type annotations where possible

Warnings:
Since this component extends FieldInput, there may be inherited properties or methods from the base class that were accessible via 'this' in the class-based component. These inheritances need to be verified to still work correctly in the Options API version. Specifically:
- The 'field' property accessed in the title computed property
- The 'store' property accessed in newImage and newAudio methods
- The 'uiValidationFunction' prop passed to child components
