### PR TITLE
refactor: convert src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue
@@ -13,16 +13,18 @@
 </template>
 
 <script lang="ts">
-import { Component } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { numberValidator } from './typeValidators';
 import { FieldInput } from '@/components/Edit/ViewableDataInputForm/FieldInput';
 
-@Component({})
-export default class NumberInput extends FieldInput {
-  public get validators() {
-    const ret = super.validators;
-    ret.unshift(numberValidator);
-    return ret;
+export default defineComponent({
+  name: 'NumberInput',
+  extends: FieldInput,
+  computed: {
+    validators(): Array<(v: any) => boolean | string> {
+      const parentValidators = FieldInput.options?.computed?.validators?.call(this) || [];
+      return [numberValidator, ...parentValidators];
+    }
   }
-}
+});
 </script>

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/NumberInput.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { numberValidator } from './typeValidators';
-import { FieldInput } from '@/components/Edit/ViewableDataInputForm/FieldInput';
+import FieldInput from '../OptionsFieldInput';
 
 export default defineComponent({
   name: 'NumberInput',
@@ -24,7 +24,7 @@ export default defineComponent({
     validators(): Array<(v: any) => boolean | string> {
       const parentValidators = FieldInput.options?.computed?.validators?.call(this) || [];
       return [numberValidator, ...parentValidators];
-    }
-  }
+    },
+  },
 });
 </script>


### PR DESCRIPTION
Summary:
This conversion involves:
1. Replacing the class-based decorator syntax with defineComponent
2. Converting the class inheritance to component extension using 'extends'
3. Moving the getter to a computed property
4. Maintaining the base class validator chain by explicitly calling the parent computed property
The component maintains its core functionality of extending FieldInput and adding number validation.

Warnings:
When accessing parent computed properties through extension, we need to be careful with the typing as TypeScript's type inference can be less precise in this pattern compared to class inheritance. The current implementation assumes FieldInput.options.computed.validators exists and returns an array of validator functions.
