### PR TITLE
refactor: convert src/components/Edit/ViewableDataInputForm/FieldInputs/StringInput.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/StringInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/StringInput.vue
@@ -12,11 +12,25 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import { FieldInput } from '../FieldInput';
+import { defineComponent, PropType } from 'vue';
+import FieldInput from '../OptionsFieldInput';
+import { FieldDefinition } from '../../../../base-course/Interfaces/FieldDefinition';
 
 export default defineComponent({
   name: 'StringInput',
-  extends: FieldInput
+  extends: FieldInput,
+
+  props: {
+    autofocus: Boolean,
+    field: Object as PropType<FieldDefinition>,
+    store: {
+      type: Object as PropType<any>,
+      required: true,
+    },
+    uiValidationFu2nction: {
+      type: Function as PropType<() => boolean>,
+      required: true,
+    },
+  },
 });
 </script>

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/StringInput.vue
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/FieldInputs/StringInput.vue
@@ -12,9 +12,11 @@
 </template>
 
 <script lang="ts">
-import { Component } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { FieldInput } from '../FieldInput';
 
-@Component
-export default class StringInput extends FieldInput {}
+export default defineComponent({
+  name: 'StringInput',
+  extends: FieldInput
+});
 </script>

--- a/packages/vue/src/components/Edit/ViewableDataInputForm/OptionsFieldInput.ts
+++ b/packages/vue/src/components/Edit/ViewableDataInputForm/OptionsFieldInput.ts
@@ -17,7 +17,10 @@ export default defineComponent({
 
   props: {
     autofocus: Boolean,
-    field: Object as PropType<FieldDefinition>,
+    field: {
+      type: Object as PropType<FieldDefinition>,
+      required: true,
+    },
     store: {
       type: Object as PropType<any>,
       required: true,


### PR DESCRIPTION
Summary:
This was a straightforward conversion since the original component was a simple extension of FieldInput with no additional functionality. The key points in the conversion were:
1. Using defineComponent for proper TypeScript support
2. Using the extends option to maintain inheritance from FieldInput
3. Adding a name property which is a good practice for debugging

Warnings:
The conversion assumes that FieldInput has been properly converted to Options API as well. If FieldInput is still using class-based syntax, this component will need to be revisited after FieldInput's conversion.
