### PR TITLE
refactor: convert src/components/PaginatingToolbar.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/PaginatingToolbar.vue
+++ b/packages/vue/src/components/PaginatingToolbar.vue
@@ -25,17 +25,32 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop } from 'vue-property-decorator';
-import Vue from 'vue';
+import { defineComponent, PropType } from 'vue'
 
-@Component
-export default class PaginatingToolbar extends Vue {
-  @Prop({ required: true }) private pages: number[];
-  @Prop({ required: true }) private page: number;
+export default defineComponent({
+  name: 'PaginatingToolbar',
+  
+  props: {
+    pages: {
+      type: Array as PropType<number[]>,
+      required: true
+    },
+    page: {
+      type: Number,
+      required: true
+    },
+    title: {
+      type: String,
+      required: false
+    },
+    subtitle: {
+      type: String,
+      required: false
+    }
+  },
 
-  @Prop({ required: false }) private title: string;
-  @Prop({ required: false }) private subtitle: string;
-}
+  emits: ['first', 'prev', 'next', 'last', 'set-page']
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
This was a straightforward conversion as the component is relatively simple. The key changes were:
1. Replaced the class-based decorator syntax with Options API
2. Used defineComponent for better TypeScript support
3. Converted @Prop decorators to a props object
4. Added explicit emits declaration for better type checking
5. Used PropType to maintain proper typing for the array prop

Warnings:
No warnings - this is a simple component with no inheritance or complex base class functionality to preserve.
