### PR TITLE
refactor: convert src/components/SkMouseTrap.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/SkMouseTrap.vue
+++ b/packages/vue/src/components/SkMouseTrap.vue
@@ -27,23 +27,29 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import Component from 'vue-class-component';
+import { defineComponent } from 'vue';
 import SkldrMouseTrap, { HotKeyMetaData } from '../SkldrMouseTrap';
 
-@Component({})
-export default class SkldrControlsView extends Vue {
-  public commands: HotKeyMetaData[] = [];
-  public display: boolean = false;
+export default defineComponent({
+  name: 'SkldrControlsView',
+  
+  data() {
+    return {
+      commands: [] as HotKeyMetaData[],
+      display: false
+    };
+  },
 
   created() {
     setInterval(this.refreshState, 500);
-  }
+  },
 
-  refreshState() {
-    // console.log(`this.display: ${this.display}`);
-    this.commands = SkldrMouseTrap.commands;
-    this.display = this.commands.length > 0;
+  methods: {
+    refreshState() {
+      // console.log(`this.display: ${this.display}`);
+      this.commands = SkldrMouseTrap.commands;
+      this.display = this.commands.length > 0;
+    }
   }
-}
+});
 </script>


### PR DESCRIPTION
Summary:
The conversion process was straightforward for this component as it had a simple structure:
1. Replaced the class-based syntax with Options API using defineComponent
2. Moved class properties to data() return object
3. Moved class methods to the methods object
4. Maintained TypeScript support via defineComponent and type annotations
5. Lifecycle hooks (created) remained functionally identical

Warnings:
No warnings - this component didn't use any inheritance or complex class features that would cause issues in the conversion. All functionality should be preserved exactly as before.
