### PR TITLE
refactor: convert src/components/Study/CardLoader.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Study/CardLoader.vue
+++ b/packages/vue/src/components/Study/CardLoader.vue
@@ -12,8 +12,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { VueConstructor } from 'vue';
-import { Component, Prop, Emit, Watch } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import Courses from '@/courses';
 import Viewable from '@/base-course/Viewable';
 import { displayableDataToViewData, ViewData } from '@/base-course/Interfaces/ViewData';
@@ -21,83 +20,91 @@ import { CardData, CardRecord, DisplayableData } from '@/db/types';
 import { log } from 'util';
 import CardViewer from './CardViewer.vue';
 import { getCourseDoc } from '@/db';
+import { VueConstructor } from 'vue';
 
-@Component({
+export default defineComponent({
+  name: 'CardLoader',
+  
   components: {
     CardViewer,
   },
-})
-export default class CardLoader extends Vue {
-  @Prop({
-    required: false,
-    default: 0,
-  })
-  public sessionOrder: number;
-  @Prop({
-    required: true,
-  })
-  public qualified_id: PouchDB.Core.DocumentId;
 
-  private loading: boolean = true;
+  props: {
+    sessionOrder: {
+      type: Number,
+      required: false,
+      default: 0,
+    },
+    qualified_id: {
+      type: String,
+      required: true,
+    },
+  },
 
-  // props for cardViewer
-  private view: VueConstructor<Viewable>;
-  private data: ViewData[] = [];
-  private constructedView: Viewable;
-  private courseID: string = '';
-  private cardID: string = '';
+  data() {
+    return {
+      loading: true,
+      view: null as VueConstructor<Viewable> | null,
+      data: [] as ViewData[],
+      constructedView: null as Viewable | null,
+      courseID: '',
+      cardID: '',
+    };
+  },
 
-  @Emit('emitResponse')
-  private processResponse(r: CardRecord) {
-    log(`
+  methods: {
+    processResponse(r: CardRecord) {
+      log(`
         Card was displayed at ${r.timeStamp}
         User spent ${r.timeSpent} milliseconds with the card.
-        `);
-  }
+      `);
+      this.$emit('emitResponse', r);
+    },
 
-  // @Watch('qualified_id')
-  private async created() {
-    const qualified_id = this.qualified_id;
-    console.log(`Card Loader displaying: ${qualified_id}`);
+    async loadCard() {
+      const qualified_id = this.qualified_id;
+      console.log(`Card Loader displaying: ${qualified_id}`);
 
-    this.loading = true;
-    const _courseID = qualified_id.split('-')[0];
-    const _cardID = qualified_id.split('-')[1];
+      this.loading = true;
+      const _courseID = qualified_id.split('-')[0];
+      const _cardID = qualified_id.split('-')[1];
 
-    try {
-      // const tmpCardData = await CardCache.getDoc<CardData>(qualified_id);
-      const tmpCardData = await getCourseDoc<CardData>(_courseID, _cardID);
-      const tmpView = Courses.getView(tmpCardData.id_view);
-      const tmpDataDocs = tmpCardData.id_displayable_data.map((id) => {
-        return getCourseDoc<DisplayableData>(_courseID, id, {
-          attachments: true,
-          binary: true,
+      try {
+        const tmpCardData = await getCourseDoc<CardData>(_courseID, _cardID);
+        const tmpView = Courses.getView(tmpCardData.id_view);
+        const tmpDataDocs = tmpCardData.id_displayable_data.map((id) => {
+          return getCourseDoc<DisplayableData>(_courseID, id, {
+            attachments: true,
+            binary: true,
+          });
         });
-      });
 
-      const tmpData = [];
+        const tmpData = [];
 
-      for (const docPromise of tmpDataDocs) {
-        const doc = await docPromise;
+        for (const docPromise of tmpDataDocs) {
+          const doc = await docPromise;
+          tmpData.unshift(displayableDataToViewData(doc));
+        }
 
-        tmpData.unshift(displayableDataToViewData(doc));
+        this.data = tmpData;
+        this.view = tmpView as VueConstructor<Viewable>;
+        this.cardID = _cardID;
+        this.courseID = _courseID;
+
+        this.constructedView = new this.view();
+      } catch (e) {
+        throw new Error(`Error loading card: ${JSON.stringify(e)}, ${e}`);
+      } finally {
+        this.loading = false;
+        this.$emit('card-loaded');
       }
+    },
+  },
 
-      this.data = tmpData;
-      this.view = tmpView as VueConstructor<Viewable>;
-      this.cardID = _cardID;
-      this.courseID = _courseID;
-
-      // bleeding memory? Do these get GCd?
-      this.constructedView = new this.view(); // [ ] remove? does this do anything?
-    } catch (e) {
-      throw new Error(`Error loading card: ${JSON.stringify(e)}, ${e}`);
-    } finally {
-      this.loading = false;
-      this.$emit('card-loaded');
-    }
-  }
-}
+  created() {
+    this.loadCard();
+  },
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Switching from class-based syntax to Options API using defineComponent
2. Converting @Prop decorators to props option
3. Converting class properties to data() returns
4. Moving class methods to methods option
5. Converting @Emit decorator to explicit  calls
6. Moving lifecycle hook to dedicated option
7. Maintaining TypeScript type annotations where possible

Warnings:
1. The type safety for the 'view' property might be slightly reduced compared to the class-based version due to the initialization with null in data()
2. The Watch decorator on 'qualified_id' was commented out in the original code, so it wasn't implemented in the conversion
