### PR TITLE
refactor: convert src/components/Study/CardViewer.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/Study/CardViewer.vue
+++ b/packages/vue/src/components/Study/CardViewer.vue
@@ -14,68 +14,72 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { ViewData } from '@/base-course/Interfaces/ViewData';
 import Viewable from '@/base-course/Viewable';
 import Courses from '@/courses';
 import { CardRecord } from '@/db/types';
 import { CourseElo } from '@/tutor/Elo';
-import Vue, { VueConstructor } from 'vue';
-import { Component, Emit, Prop } from 'vue-property-decorator';
+import { VueConstructor } from 'vue';
 
-@Component({
+export default defineComponent({
+  name: 'CardViewer',
+  
   components: Courses.allViews(),
-})
-export default class CardViewer extends Vue {
-  @Prop({
-    required: false,
-    default: 0,
-  })
-  public sessionOrder: number;
-  @Prop({
-    required: true,
-    default: '',
-  })
-  public card_id: PouchDB.Core.DocumentId;
-  @Prop({
-    required: true,
-    default: '',
-  })
-  public course_id: string;
-  @Prop() public view: VueConstructor<Viewable>;
-  @Prop() public data: ViewData[];
-  @Prop({
-    default: () => {
-      return {
+  
+  props: {
+    sessionOrder: {
+      type: Number,
+      required: false,
+      default: 0
+    },
+    card_id: {
+      type: String as () => PouchDB.Core.DocumentId,
+      required: true,
+      default: ''
+    },
+    course_id: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    view: {
+      type: Object as () => VueConstructor<Viewable>,
+      required: true
+    },
+    data: {
+      type: Array as () => ViewData[],
+      required: true
+    },
+    user_elo: {
+      type: Object as () => CourseElo,
+      default: () => ({
         global: {
           score: 1000,
-          count: 0,
+          count: 0
         },
         tags: {},
-        misc: {},
-      };
+        misc: {}
+      })
     },
-  })
-  public user_elo: CourseElo = {
-    global: {
-      score: 1000,
-      count: 0,
-    },
-    tags: {},
-    misc: {},
-  };
-  @Prop({
-    default: 1000,
-  })
-  public card_elo: number;
+    card_elo: {
+      type: Number,
+      default: 1000
+    }
+  },
 
-  @Emit('emitResponse')
-  private processResponse(r: CardRecord) {
-    console.log(`
+  emits: ['emitResponse'],
+
+  methods: {
+    processResponse(r: CardRecord): void {
+      console.log(`
         Card was displayed at ${r.timeStamp}
         User spent ${r.timeSpent} milliseconds with the card.
         `);
+      this.$emit('emitResponse', r);
+    }
   }
-}
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Switching from class-based syntax to Options API using defineComponent
2. Converting @Prop decorators to props option object
3. Converting @Emit decorator to explicit  call
4. Maintaining TypeScript type safety through type assertions in props
5. Adding explicit emits declaration for type checking

Warnings:
No significant functionality issues are expected in this conversion as:
- The component doesn't extend any base class
- All prop defaults are preserved
- Event emission behavior remains the same
- Type safety is maintained through proper type assertions
