### PR TITLE
refactor: convert src/components/TextSwap.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/components/TextSwap.vue
+++ b/packages/vue/src/components/TextSwap.vue
@@ -5,30 +5,37 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import Component from 'vue-class-component';
-import { Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-@Component({})
-export default class TextSwap extends Vue {
-  @Prop({
-    type: Array,
-    required: true,
-  })
-  private text: string[];
-  private index: number = 0;
+export default defineComponent({
+  name: 'TextSwap',
+  
+  props: {
+    text: {
+      type: Array as () => string[],
+      required: true
+    }
+  },
 
-  public next() {
-    if (this.text.length > 1) {
-      const previous = this.index;
-      // this.index = -1; // triggering animation
-      // this.index = previous;
-      while (this.index === previous) {
-        this.index = Math.floor(Math.random() * this.text.length);
+  data() {
+    return {
+      index: 0
+    };
+  },
+
+  methods: {
+    next() {
+      if (this.text.length > 1) {
+        const previous = this.index;
+        // this.index = -1; // triggering animation
+        // this.index = previous;
+        while (this.index === previous) {
+          this.index = Math.floor(Math.random() * this.text.length);
+        }
       }
     }
   }
-}
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Replacing the class-based syntax with Options API
2. Moving the @Prop decorator to props option
3. Moving the class property to data()
4. Moving the class method to methods option
5. Using defineComponent for better TypeScript support
6. Properly typing the props Array as string[]

The conversion is straightforward as this is a relatively simple component without complex inheritance or lifecycle hooks.

Warnings:
No warnings - this component has no base class dependencies or complex functionality that would cause issues during conversion.
