### PR TITLE
refactor: convert src/courses/components/MusicScoreRender.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/courses/components/MusicScoreRender.vue
+++ b/packages/vue/src/courses/components/MusicScoreRender.vue
@@ -4,17 +4,22 @@
 
 <script lang="ts">
 import abc from 'abcjs';
-import Component from 'vue-class-component';
-import { Prop, Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-@Component({})
-export default class MusicScoreRenderer extends Vue {
-  @Prop() public abcString: string;
+export default defineComponent({
+  name: 'MusicScoreRenderer',
 
-  public mounted() {
+  props: {
+    abcString: {
+      type: String,
+      required: true
+    }
+  },
+
+  mounted() {
     abc.renderAbc('abc', this.abcString);
   }
-}
+});
 </script>
 
 <style>


### PR DESCRIPTION
Summary:
This was a straightforward conversion of a simple component. The main changes were:
1. Removing class-based decorators
2. Using defineComponent for better type inference
3. Converting the class structure to the Options API format
4. Making the prop required since it's used in mounted() without a default value

Warnings:
No warnings - this component had no inheritance or complex class-based features that would cause issues in conversion.
