### PR TITLE
refactor: convert src/courses/default/questions/basic/BasicCard.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/courses/default/questions/basic/BasicCard.vue
+++ b/packages/vue/src/courses/default/questions/basic/BasicCard.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { InformationView } from '@/base-course/Viewable';
 import UserInputNumber from '@/base-course/Components/UserInput/UserInputNumber.vue';
 import { Displayable } from '@/base-course/Displayable';
@@ -39,20 +39,31 @@ class BasicCard extends Displayable {
   }
 }
 
-// tslint:disable-next-line:max-classes-per-file
-@Component({
+export default defineComponent({
+  name: 'BasicView',
+  
   components: {
     UserInputNumber,
   },
-})
-export default class BasicView extends InformationView<BasicCard> {
-  public answer: string = '';
 
-  public get displayable() {
-    return new BasicCard(this.data);
-  }
-  public submit() {
-    // (no nag tslint!)
-  }
-}
+  data() {
+    return {
+      answer: '',
+    };
+  },
+
+  computed: {
+    displayable(): BasicCard {
+      return new BasicCard(this.data);
+    }
+  },
+
+  methods: {
+    submit(): void {
+      // (no nag tslint!)
+    }
+  },
+
+  extends: InformationView
+});
 </script>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Replacing the class-based component decorator with defineComponent()
2. Moving the @Component decorator options into the component definition
3. Converting class properties to data() returns
4. Converting class methods to the methods object
5. Converting getters to computed properties
6. Maintaining the inheritance chain using 'extends'
7. Preserving type information where possible using TypeScript annotations

Warnings:
1. The type safety for the generic parameter of InformationView<BasicCard> may be reduced in the Options API version. The extends syntax doesn't provide a way to specify generic type parameters as clearly as the class syntax did.
2. There might be protected/private methods or properties in the InformationView base class that were accessible in the class-based version but might have different visibility in the Options API version.
