### PR TITLE
refactor: convert src/views/User.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/base-course/Course.ts
+++ b/packages/vue/src/base-course/Course.ts
@@ -1,4 +1,4 @@
-import { Displayable, ViewComponent } from '../base-course/Displayable';
+import { Displayable } from '../base-course/Displayable';
 import Vue, { VueConstructor } from 'vue';
 import defaultCourse from '../courses/default';
 import { BlanksCard } from '../courses/default/questions/fillIn/';
@@ -9,8 +9,8 @@ export class Course {
     return this.questionList;
   }
 
-  public get allViews(): Array<ViewComponent> {
-    const ret = new Array<ViewComponent>();
+  public get allViews(): Array<VueConstructor<Vue>> {
+    const ret = new Array<VueConstructor<Vue>>();
 
     this.questionList.forEach((question) => {
       question.views.forEach((view) => {
@@ -25,15 +25,11 @@ export class Course {
    * This function returns the map {[index:string]: string} of display
    * components needed by the CardViewer component
    */
-  public get allViewsMap(): { [index: string]: ViewComponent } {
-    const ret: { [index: string]: ViewComponent } = {};
+  public get allViewsMap(): { [index: string]: VueConstructor<Vue> } {
+    const ret: { [index: string]: VueConstructor<Vue> } = {};
 
     this.allViews.forEach((view) => {
-      if (view.name) {
-        ret[view.name] = view;
-      } else {
-        throw new Error('View has no name');
-      }
+      ret[view.name] = view;
     });
 
     return ret;

--- a/packages/vue/src/components/Courses/CourseCardBrowser.vue
+++ b/packages/vue/src/components/Courses/CourseCardBrowser.vue
@@ -110,15 +110,6 @@ import { removeTagFromCard } from '@/db/courseDB';
 import { CardData, DisplayableData, DocType, Tag } from '@/db/types';
 import Vue from 'vue';
 
-function isConstructor(obj: any) {
-  try {
-    new obj();
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
 export default Vue.extend({
   name: 'CourseCardBrowser',
 
@@ -292,16 +283,10 @@ export default Vue.extend({
             const tmpData = [];
             tmpData.unshift(displayableDataToViewData(doc));
 
-            // [ ] remove/replace this after the vue 3 migration is complete
-            // see PR #510
-            if (isConstructor(tmpView)) {
-              const view = new tmpView();
-              (view as any).data = tmpData;
+            const view = new tmpView();
+            (view as any).data = tmpData;
 
-              this.cardPreview[c.id] = view.toString();
-            } else {
-              this.cardPreview[c.id] = tmpView.name ? tmpView.name : 'Unknown';
-            }
+            this.cardPreview[c.id] = view.toString();
           })
         );
 

--- a/packages/vue/src/components/Edit/ComponentRegistration/ComponentRegistration.vue
+++ b/packages/vue/src/components/Edit/ComponentRegistration/ComponentRegistration.vue
@@ -163,13 +163,7 @@ export default defineComponent({
 
       this.courseConfig!.questionTypes.push({
         name: nsQuestionName,
-        viewList: question.question.views.map((v) => {
-          if (v.name) {
-            return v.name;
-          } else {
-            return 'unnamedComponent';
-          }
-        }),
+        viewList: question.question.views.map((v) => v.name),
         dataShapeList: question.question.dataShapes.map((d) =>
           NameSpacer.getDataShapeString({
             course: question.course,

--- a/packages/vue/src/components/Study/CardLoader.vue
+++ b/packages/vue/src/components/Study/CardLoader.vue
@@ -1,6 +1,5 @@
 <template>
   <card-viewer
-    class="ma-2"
     v-if="!loading"
     v-bind:class="loading ? 'muted' : ''"
     v-bind:view="view"
@@ -15,16 +14,17 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import Courses from '@/courses';
+import Viewable from '@/base-course/Viewable';
 import { displayableDataToViewData, ViewData } from '@/base-course/Interfaces/ViewData';
 import { CardData, CardRecord, DisplayableData } from '@/db/types';
 import { log } from 'util';
 import CardViewer from './CardViewer.vue';
 import { getCourseDoc } from '@/db';
-import { ViewComponent } from '@/base-course/Displayable';
+import { VueConstructor } from 'vue';
 
 export default defineComponent({
   name: 'CardLoader',
-
+  
   components: {
     CardViewer,
   },
@@ -44,8 +44,9 @@ export default defineComponent({
   data() {
     return {
       loading: true,
-      view: null as ViewComponent | null,
+      view: null as VueConstructor<Viewable> | null,
       data: [] as ViewData[],
+      constructedView: null as Viewable | null,
       courseID: '',
       cardID: '',
     };
@@ -86,9 +87,11 @@ export default defineComponent({
         }
 
         this.data = tmpData;
-        this.view = tmpView as ViewComponent;
+        this.view = tmpView as VueConstructor<Viewable>;
         this.cardID = _cardID;
         this.courseID = _courseID;
+
+        this.constructedView = new this.view();
       } catch (e) {
         throw new Error(`Error loading card: ${JSON.stringify(e)}, ${e}`);
       } finally {

--- a/packages/vue/src/components/Study/CardViewer.vue
+++ b/packages/vue/src/components/Study/CardViewer.vue
@@ -2,7 +2,7 @@
   <v-card elevation="12">
     <transition name="component-fade" mode="out-in">
       <component
-        class="cardView ma-2 pa-2"
+        class="cardView"
         v-bind:is="view"
         v-bind:data="data"
         v-bind:key="course_id + '-' + card_id + '-' + sessionOrder"
@@ -14,60 +14,58 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { defineComponent } from 'vue';
 import { ViewData } from '@/base-course/Interfaces/ViewData';
 import Viewable from '@/base-course/Viewable';
 import Courses from '@/courses';
 import { CardRecord } from '@/db/types';
 import { CourseElo } from '@/tutor/Elo';
 import { VueConstructor } from 'vue';
-import { DefineComponent } from 'vue';
-import { ViewComponent } from '@/base-course/Displayable';
 
 export default defineComponent({
   name: 'CardViewer',
-
+  
   components: Courses.allViews(),
-
+  
   props: {
     sessionOrder: {
       type: Number,
       required: false,
-      default: 0,
+      default: 0
     },
     card_id: {
       type: String as () => PouchDB.Core.DocumentId,
       required: true,
-      default: '',
+      default: ''
     },
     course_id: {
       type: String,
       required: true,
-      default: '',
+      default: ''
     },
     view: {
-      type: [Function, Object] as PropType<ViewComponent>,
-      required: true,
+      type: Object as () => VueConstructor<Viewable>,
+      required: true
     },
     data: {
       type: Array as () => ViewData[],
-      required: true,
+      required: true
     },
     user_elo: {
       type: Object as () => CourseElo,
       default: () => ({
         global: {
           score: 1000,
-          count: 0,
+          count: 0
         },
         tags: {},
-        misc: {},
-      }),
+        misc: {}
+      })
     },
     card_elo: {
       type: Number,
-      default: 1000,
-    },
+      default: 1000
+    }
   },
 
   emits: ['emitResponse'],
@@ -79,8 +77,8 @@ export default defineComponent({
         User spent ${r.timeSpent} milliseconds with the card.
         `);
       this.$emit('emitResponse', r);
-    },
-  },
+    }
+  }
 });
 </script>
 

--- a/packages/vue/src/courses/chess/index.ts
+++ b/packages/vue/src/courses/chess/index.ts
@@ -1,6 +1,6 @@
 import { Course } from '../../base-course/Course';
-import { Puzzle } from './questions/puzzle';
+import { ChessPuzzle } from './questions/puzzle';
 
-const chess: Course = new Course('chess', [Puzzle]);
+const chess: Course = new Course('chess', [ChessPuzzle]);
 
 export default chess;

--- a/packages/vue/src/courses/chess/questions/puzzle/index.ts
+++ b/packages/vue/src/courses/chess/questions/puzzle/index.ts
@@ -1,4 +1,4 @@
-import { Answer, Question, ViewComponent } from '@/base-course/Displayable';
+import { Answer, Question } from '@/base-course/Displayable';
 import { DataShape } from '@/base-course/Interfaces/DataShape';
 import { ViewData } from '@/base-course/Interfaces/ViewData';
 import { DataShapeName } from '@/enums/DataShapeNames';
@@ -7,7 +7,7 @@ import { Status } from '@/enums/Status';
 import PuzzleView from './puzzle.vue';
 import { Key as cgKey } from '../../chessground/types';
 
-export class Puzzle extends Question {
+export class ChessPuzzle extends Question {
   public static dataShapes: DataShape[] = [
     {
       name: DataShapeName.CHESS_puzzle,
@@ -17,7 +17,7 @@ export class Puzzle extends Question {
           type: FieldType.CHESS_PUZZLE,
           validator: {
             instructions: 'insert a valid fen string',
-            test: function (s: string) {
+            test: function(s: string) {
               console.log(`running puzzle validator on ${s}`);
 
               if (!s) {
@@ -49,7 +49,7 @@ export class Puzzle extends Question {
       ],
     },
   ];
-  public static views: ViewComponent[] = [PuzzleView];
+  public static views = [PuzzleView];
   public static acceptsUserData: boolean = true;
 
   public static readonly CHECKMATE = 'CHECKMATE';
@@ -94,17 +94,17 @@ export class Puzzle extends Question {
     return 0.5;
   }
   dataShapes() {
-    return Puzzle.dataShapes;
+    return ChessPuzzle.dataShapes;
   }
 
-  views(): Array<ViewComponent> {
-    return Puzzle.views;
+  views() {
+    return ChessPuzzle.views;
   }
 
   isCorrect(a: Answer) {
     // player actions have exhausted the move tree
     const sequenceComplete = this.moves.length === 0;
 
-    return a === Puzzle.CHECKMATE || sequenceComplete;
+    return a === ChessPuzzle.CHECKMATE || sequenceComplete;
   }
 }

--- a/packages/vue/src/courses/index.ts
+++ b/packages/vue/src/courses/index.ts
@@ -9,7 +9,7 @@ import piano from './piano';
 import chess from './chess';
 import defaultCourse from './default';
 import Viewable from '../base-course/Viewable';
-import { Displayable, ViewComponent } from '../base-course/Displayable';
+import { Displayable } from '../base-course/Displayable';
 import pitch from './pitch';
 import sightSing from './sightsing';
 import { NameSpacer, ShapeDescriptor, ViewDescriptor } from './NameSpacer';
@@ -26,7 +26,7 @@ export class CourseList {
   }
 
   public getCourse(name: string): Course | undefined {
-    return this.courseList.find((course) => {
+    return this.courseList.find(course => {
       return course.name === name;
     });
   }
@@ -38,14 +38,14 @@ export class CourseList {
   public allViews(): { [index: string]: VueConstructor<Vue> } {
     const ret: { [index: string]: VueConstructor<Vue> } = {};
 
-    this.courseList.forEach((course) => {
+    this.courseList.forEach(course => {
       Object.assign(ret, course.allViewsMap);
     });
 
     return ret;
   }
 
-  public getView(viewDescription: ViewDescriptor | string): ViewComponent {
+  public getView(viewDescription: ViewDescriptor | string): VueConstructor {
     let description: ViewDescriptor;
     if (typeof viewDescription === 'string') {
       description = NameSpacer.getViewDescriptor(viewDescription);
@@ -57,22 +57,19 @@ export class CourseList {
     if (course) {
       const question = course.getQuestion(description.questionType);
       if (question) {
-        const ret = question.views.find((view) => {
+        const ret = question.views.find(view => {
           return view.name === description.view;
         });
 
         if (ret) {
           return ret;
         } else {
-          console.error(`${description.view} not found in course ${description.course}`);
           throw new Error(`view ${description.view} does not exist.`);
         }
       } else {
-        console.error(`${description.questionType} not found in course ${description.course}`);
         throw new Error(`question ${description.questionType} does not exist.`);
       }
     } else {
-      console.error(`${description.course} not found.`);
       throw new Error(`course ${description.course} does not exist.`);
     }
   }
@@ -80,9 +77,9 @@ export class CourseList {
   public allDataShapesRaw(): DataShape[] {
     const ret: DataShape[] = [];
 
-    this.courseList.forEach((course) => {
-      course.questions.forEach((question) => {
-        question.dataShapes.forEach((shape) => {
+    this.courseList.forEach(course => {
+      course.questions.forEach(question => {
+        question.dataShapes.forEach(shape => {
           if (!ret.includes(shape)) {
             ret.push(shape);
           }
@@ -96,14 +93,14 @@ export class CourseList {
   public allDataShapes(): (ShapeDescriptor & { displayable: typeof Displayable })[] {
     const ret: (ShapeDescriptor & { displayable: typeof Displayable })[] = [];
 
-    this.courseList.forEach((course) => {
-      course.questions.forEach((question) => {
-        question.dataShapes.forEach((shape) => {
+    this.courseList.forEach(course => {
+      course.questions.forEach(question => {
+        question.dataShapes.forEach(shape => {
           // [ ] need to de-dup shapes here. Currently, if a shape is used in multiple courses
           //     it will be returned multiple times.
           //     `Blanks` shape is is hard coded into new courses, so gets returned many times
           if (
-            ret.findIndex((testShape) => {
+            ret.findIndex(testShape => {
               return testShape.course === course.name && testShape.dataShape === shape.name;
             }) === -1
           ) {
@@ -123,8 +120,8 @@ export class CourseList {
   public getDataShape(description: ShapeDescriptor): DataShape {
     let ret: DataShape | undefined;
 
-    this.getCourse(description.course)!.questions.forEach((question) => {
-      question.dataShapes.forEach((shape) => {
+    this.getCourse(description.course)!.questions.forEach(question => {
+      question.dataShapes.forEach(shape => {
         if (shape.name === description.dataShape) {
           ret = shape;
         }

--- a/packages/vue/src/mocks/UIMocks.vue
+++ b/packages/vue/src/mocks/UIMocks.vue
@@ -122,7 +122,7 @@ import PuzzleView from '@/courses/chess/questions/puzzle/puzzle.vue';
 import ChessPieceMove from '@/courses/chess/questions/piecemove/piece-move.vue';
 import FillInView from '@/courses/default/questions/fillIn/fillIn.vue';
 import { BlanksCardDataShapes } from '@/courses/default/questions/fillIn/index';
-import { Puzzle } from '@/courses/chess/questions/puzzle/index';
+import { ChessPuzzle } from '@/courses/chess/questions/puzzle/index';
 import { Component } from 'vue-property-decorator';
 import DataInputForm from '../components/Edit/ViewableDataInputForm/DataInputForm.vue';
 import LetterQuestionView from '@/courses/typing/questions/single-letter/typeSingleLetter.vue';
@@ -158,7 +158,7 @@ export default class SkTagsInputMock extends Vue {
     'v2n1N,5Q1k/2pbq1p1/8/pp1P4/4B1P1/7P/PP6/1K3R2 b - - 4 34,e7f8 f1f8,615,86,73,189,endgame mate mateIn1 oneMove,https://lichess.org/Czh6F7z3/black#68,';
   promotionPuzzle = `o2mD7,8/2K5/p4p2/8/1P4k1/8/P7/8 w - - 0 35,c7b7 f6f5 b7a6 f5f4 b4b5 f4f3 b5b6 f3f2 b6b7 f2f1q,846,99,92,589,advancedPawn crushing endgame pawnEndgame promotion quietMove veryLong,https://lichess.org/x0LpCJ7V#69,`;
   BlanksCardDataShapes = BlanksCardDataShapes;
-  ChessPuzzleDataShapes = Puzzle.dataShapes;
+  ChessPuzzleDataShapes = ChessPuzzle.dataShapes;
   FillInView = FillInView;
 
   created() {

--- a/packages/vue/src/views/User.vue
+++ b/packages/vue/src/views/User.vue
@@ -26,69 +26,80 @@
 
 <script lang="ts">
 import confetti from 'canvas-confetti';
-import { Component, Prop } from 'vue-property-decorator';
-import Vue from 'vue';
+import { defineComponent, PropType } from 'vue';
 
-@Component({})
-export default class User extends Vue {
-  @Prop({
-    required: true,
-  })
-  public _id: string;
-  private u = this.$store.state._user!;
+interface Language {
+  name: string;
+  code: string;
+}
 
-  public confetti: boolean = this.$store.state.config.likesConfetti;
-  public darkMode: boolean = this.$store.state.config.darkMode;
+export default defineComponent({
+  name: 'User',
 
-  public configLanguages: {
-    name: string;
-    code: string;
-  }[] = [
-    {
-      name: 'English',
-      code: 'en',
-    },
-    {
-      name: 'French',
-      code: 'fr',
-    },
-  ];
-  public selectedLanguages: string[] = [];
-
-  updateDark() {
-    this.u.setConfig({
-      darkMode: this.darkMode,
-    });
-    this.$store.state.config.darkMode = this.darkMode;
-  }
-
-  updateConfetti() {
-    console.log(`Confetti updated...`);
-    this.u.setConfig({
-      likesConfetti: this.confetti,
-    });
-    this.$store.state.config.likesConfetti = this.confetti;
-
-    if (this.$store.state.config.likesConfetti) {
-      confetti({
-        origin: {
-          x: 0.5,
-          y: 1,
-        },
-      });
+  props: {
+    _id: {
+      type: String,
+      required: true
     }
-  }
+  },
 
-  public get isNewUser(): boolean {
-    return this.$route.path.endsWith('new');
-  }
+  data() {
+    return {
+      u: this.$store.state._user!,
+      confetti: this.$store.state.config.likesConfetti as boolean,
+      darkMode: this.$store.state.config.darkMode as boolean,
+      configLanguages: [
+        {
+          name: 'English',
+          code: 'en',
+        },
+        {
+          name: 'French',
+          code: 'fr',
+        },
+      ] as Language[],
+      selectedLanguages: [] as string[]
+    }
+  },
+
+  computed: {
+    isNewUser(): boolean {
+      return this.$route.path.endsWith('new');
+    }
+  },
+
+  methods: {
+    updateDark(): void {
+      this.u.setConfig({
+        darkMode: this.darkMode,
+      });
+      this.$store.state.config.darkMode = this.darkMode;
+    },
+
+    updateConfetti(): void {
+      console.log(`Confetti updated...`);
+      this.u.setConfig({
+        likesConfetti: this.confetti,
+      });
+      this.$store.state.config.likesConfetti = this.confetti;
+
+      if (this.$store.state.config.likesConfetti) {
+        confetti({
+          origin: {
+            x: 0.5,
+            y: 1,
+          },
+        });
+      }
+    }
+  },
 
   created() {
     this.configLanguages.forEach((l) => {
       console.log(`afweatifvwzeatfvwzeta` + l.name);
     });
   }
-}
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Replacing the class-based structure with Options API
2. Converting @Prop decorator to props option
3. Moving class properties to data() function
4. Converting class methods to methods option
5. Moving getter to computed option
6. Added TypeScript interfaces for better type safety
7. Using defineComponent for better TypeScript support

Warnings:
The TypeScript support might be slightly less strict compared to the class-based version, particularly around the store state typing. The original version's store access through this.u = this..state._user! maintained the non-null assertion, but the type inference in the Options API version might be less precise. Consider adding explicit store state type definitions if stricter type checking is needed.
