### PR TITLE
refactor: convert src/views/Admin.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/views/Admin.vue
+++ b/packages/vue/src/views/Admin.vue
@@ -29,28 +29,33 @@
 </template>
 
 <script lang="ts">
-import Vue, { VueConstructor } from 'vue';
-import { Component, Prop, Emit } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { log } from 'util';
 import AdminDB from '../db/adminDB';
 import { GuestUsername } from '../store';
 
-@Component({})
-export default class Admin extends Vue {
-  public title: string = 'Admin Panel';
+export default defineComponent({
+  name: 'Admin',
 
-  public db: AdminDB;
-  public users: any[] = [];
-  public courses: any[] = [];
-  public classrooms: any[] = [];
+  data() {
+    return {
+      title: 'Admin Panel',
+      db: null as AdminDB | null,
+      users: [] as any[],
+      courses: [] as any[],
+      classrooms: [] as any[]
+    };
+  },
 
-  public get registeredUsers(): any[] {
-    return this.users.filter((u) => {
-      return !(u.name as string).startsWith(GuestUsername);
-    });
-  }
+  computed: {
+    registeredUsers(): any[] {
+      return this.users.filter((u) => {
+        return !(u.name as string).startsWith(GuestUsername);
+      });
+    }
+  },
 
-  public async created() {
+  async created() {
     try {
       this.db = await AdminDB.factory();
       this.users = await this.db.getUsers();
@@ -60,13 +65,17 @@ export default class Admin extends Vue {
       this.title = 'This page is for database admins only.';
       throw `${JSON.stringify(e)} - ${e}\n\nNot an admin!`;
     }
-  }
+  },
 
-  public removeCourse(id: string) {
-    console.log(`Removing ${id}`);
-    this.db.removeCourse(id);
+  methods: {
+    removeCourse(id: string): void {
+      console.log(`Removing ${id}`);
+      if (this.db) {
+        this.db.removeCourse(id);
+      }
+    }
   }
-}
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
Summary:
The conversion process involved:
1. Replacing the class-based syntax with Options API format using defineComponent
2. Moving class properties to the data() function
3. Converting class methods to the methods object
4. Moving computed property to the computed object
5. Adding proper type annotations for data properties
6. Adding null checking for the db property since it's initialized asynchronously
7. Removing unnecessary decorator imports

Warnings:
1. Type safety for the users, courses, and classrooms arrays is reduced since they're typed as any[]. Consider creating proper interfaces for these data structures.
2. The db property is now nullable (AdminDB | null) which required adding a null check in the removeCourse method. This is more type-safe but different from the original implementation.
