### PR TITLE
refactor: convert src/views/ReleaseNotes.vue from class-based to Options/Composition API

### DIFF
--- a/packages/vue/src/views/ReleaseNotes.vue
+++ b/packages/vue/src/views/ReleaseNotes.vue
@@ -10,12 +10,12 @@
 </template>
 
 <script lang="ts">
-import Vue, { VueConstructor } from 'vue';
-import { Component, Prop, Emit } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { log } from 'util';
 
-@Component({})
-export default class User extends Vue {}
+export default defineComponent({
+  name: 'ReleaseNotes'
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
Summary:
This was a straightforward conversion of a minimal class-based component to Options API.
The component had:
- No props
- No emits
- No methods
- No computed properties
- No lifecycle hooks

The main changes were:
1. Removed vue-property-decorator imports as they weren't used
2. Replaced class syntax with defineComponent
3. Added explicit name property matching filename
4. Removed Vue import as it's not needed with defineComponent

Warnings:
No warnings - this was a basic component with no base class functionality to preserve.
