### PR TITLE
hotfix fillin mixing

### DIFF
--- a/packages/vue/src/courses/default/questions/fillIn/index.ts
+++ b/packages/vue/src/courses/default/questions/fillIn/index.ts
@@ -234,42 +234,6 @@ export class BlanksCard extends Question {
     }
   }
 
-  findAnswers(tok: marked.Token): {
-    answers: string[] | null;
-    options: string[] | null;
-  } | null {
-    // todo: enable multi-blanks
-    //
-
-    if (tok.type === 'text') {
-      if (isComponent(tok)) {
-        this.answersFromString(tok.raw.substring(2, tok.raw.length - 2));
-      }
-
-      if (containsComponent(tok)) {
-        const split = this.splitTextToken(tok as marked.Tokens.Text);
-        for (let i = 0; i < split.length; i++) {
-          if (isComponent(split[i])) {
-            return this.findAnswers(split[i]);
-          }
-        }
-      }
-    }
-
-    const toks: { tokens: marked.Token[] } = tok as { tokens: marked.Token[] };
-
-    if (toks.tokens) {
-      for (let i = 0; i < toks.tokens.length; i++) {
-        const candidate = this.findAnswers(toks.tokens[i]);
-        if (candidate !== null) {
-          return candidate;
-        }
-      }
-    }
-
-    return null;
-  }
-
   private answersFromString(s: string) {
     if (!s.startsWith('{{') || !s.endsWith('}}')) {
       throw new Error(`string ${s} is not fill-in text - must look like "{{someText}}"`);


### PR DESCRIPTION
PR fixes (I think) a tricky issue where fill-in-the-blank question with multiple choice options was incorrectly reshuffling its options after each answer attempt.

Hypothesis: This occurred because a `watchEffect` was reacting to ELO score changes that happen after each answer. 

Fix: replaced `watchEffect` with a more specific `watch` that only triggers on data changes, preventing unwanted reshuffling while maintaining the component's ability to initialize properly and respond to actual content updates. The original behavior was confusing for users and could make correct answers unavailable if they landed in a previously-selected position.

- **remove unused answer parse method...**
- **specify watcher to only the `data` prop...**
