### PR TITLE
docker container cleanup

### DIFF
--- a/scripts/cleanup-test.js
+++ b/scripts/cleanup-test.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+
+// Docker container name
+const CONTAINER_NAME = 'skuilder-test-couch';
+
+console.log('Running container cleanup test...');
+
+try {
+  // Check if the container exists
+  const containerExists = execSync(`docker ps -a -q -f name=^${CONTAINER_NAME}$`, { stdio: 'pipe' }).toString().trim();
+  
+  if (containerExists) {
+    console.log(`Found existing container '${CONTAINER_NAME}'. Cleaning up...`);
+    
+    try {
+      // Check if container is running
+      const isRunning = execSync(`docker ps -q -f name=^${CONTAINER_NAME}$`, { stdio: 'pipe' }).toString().trim();
+      if (isRunning) {
+        console.log('Container is running. Stopping it...');
+        execSync(`docker stop ${CONTAINER_NAME}`, { stdio: 'pipe' });
+        console.log('Container stopped successfully.');
+      } else {
+        console.log('Container is not running.');
+      }
+      
+      // Remove the container
+      console.log('Removing container...');
+      execSync(`docker rm ${CONTAINER_NAME}`, { stdio: 'pipe' });
+      console.log('Container removed successfully.');
+      
+    } catch (error) {
+      console.error('Error during cleanup:', error.message);
+      process.exit(1);
+    }
+  } else {
+    console.log(`No container named '${CONTAINER_NAME}' found. Nothing to clean up.`);
+  }
+  
+  console.log('Cleanup test completed successfully.');
+  
+} catch (error) {
+  console.error('Error checking container status:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

When working with git worktrees or multiple clones of the repository on
the same machine, the CouchDB Docker container setup can cause
conflicts. This happens because:

1. Multiple worktrees try to use the same container name
(`skuilder-test-couch`)
2. Docker attempts to mount volumes to paths that may already exist in
other containers
3. This results in errors like:
   ```
   Error response from daemon: failed to create task for container:
failed to create shim task: OCI runtime create failed: runc create
failed: unable to start container process: error during container init:
error mounting "/path/to/local.ini" to rootfs at
"/opt/couchdb/etc/local.ini"
   ```

## Solution

Automatic cleanup process in the `dev-couchdb.js` script that runs
before starting CouchDB. This process:

1. Checks if a container with the name `skuilder-test-couch` already
exists
2. If it exists:
   - Stops the container if it's running
   - Removes the container
3. Continues with the normal start process using the test-couch.sh
script

This ensures that each time you start CouchDB, you get a fresh container
without conflicts from previous runs or other worktrees.
