### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/ci-mcp-sanity.yml
+++ b/.github/workflows/ci-mcp-sanity.yml
@@ -37,8 +37,10 @@ jobs:
         run: |
           yarn couchdb:start
 
-      - name: Build mcp package
-        run: yarn workspace @vue-skuilder/mcp build
+      - name: Build mcp package and examples
+        run: |
+          yarn workspace @vue-skuilder/mcp build
+          yarn workspace @vue-skuilder/mcp build:examples
 
       - name: list resources
         run: |
@@ -46,7 +48,7 @@ jobs:
 
       - name: list tools
         run: |
-          yarn workspace @vue-skuilder/mcp test:resources
+          yarn workspace @vue-skuilder/mcp test:tools
 
       - name: list prompts
         run: |

--- a/.github/workflows/ci-mcp-sanity.yml
+++ b/.github/workflows/ci-mcp-sanity.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
 
       - name: Install Yarn

--- a/.github/workflows/ci-mcp-sanity.yml
+++ b/.github/workflows/ci-mcp-sanity.yml
@@ -38,6 +38,9 @@ jobs:
           yarn couchdb:start
           npx wait-on --timeout 5m http://localhost:5984
 
+      - name: Verify databases
+        run: curl http://admin:password@localhost:5984/_all_dbs
+
       - name: Build mcp package and examples
         run: |
           yarn workspace @vue-skuilder/mcp build

--- a/.github/workflows/ci-mcp-sanity.yml
+++ b/.github/workflows/ci-mcp-sanity.yml
@@ -46,6 +46,9 @@ jobs:
           yarn workspace @vue-skuilder/mcp build
           yarn workspace @vue-skuilder/mcp build:examples
 
+      - name: Run local-dev script directly
+        run: timeout 90s node packages/mcp/dist/examples/local-dev.mjs || true
+
       - name: list resources
         run: |
           yarn workspace @vue-skuilder/mcp test:resources

--- a/.github/workflows/ci-mcp-sanity.yml
+++ b/.github/workflows/ci-mcp-sanity.yml
@@ -46,9 +46,6 @@ jobs:
           yarn workspace @vue-skuilder/mcp build
           yarn workspace @vue-skuilder/mcp build:examples
 
-      - name: Run local-dev script directly
-        run: timeout 90s node packages/mcp/dist/examples/local-dev.mjs || true
-
       - name: list resources
         run: |
           yarn workspace @vue-skuilder/mcp test:resources

--- a/.github/workflows/ci-mcp-sanity.yml
+++ b/.github/workflows/ci-mcp-sanity.yml
@@ -36,6 +36,7 @@ jobs:
       - name: run test database
         run: |
           yarn couchdb:start
+          npx wait-on --timeout 5m http://localhost:5984
 
       - name: Build mcp package and examples
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,11 +47,11 @@ jobs:
           # Start the dev environment in background
           yarn dev:platform &
           # Wait for the webserver to be ready
-          npx wait-on http://localhost:5173
+          npx wait-on --timeout 5m http://localhost:5173
           # Wait for the database to be ready
-          npx wait-on http://localhost:5984
+          npx wait-on --timeout 5m http://localhost:5984
           # Wait for the backend to be ready
-          npx wait-on http://localhost:3000
+          npx wait-on --timeout 5m http://localhost:3000
 
       - name: Run E2E tests
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup and wait for services
         run: |
           # Start the dev environment in background
-          yarn dev &
+          yarn dev:platform &
           # Wait for the webserver to be ready
           npx wait-on http://localhost:5173
           # Wait for the database to be ready

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install Cypress
         run: yarn workspace @vue-skuilder/platform-ui cypress install
 
+      - name: Build prereqs
+        run: yarn build:lib
+
       - name: Setup and wait for services
         run: |
           # Start the dev environment in background

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -158,9 +158,7 @@ jobs:
           
           # Dual-publish CLI as unscoped 'skuilder' package
           echo "Publishing CLI as 'skuilder'..."
-          TEMP_DIR=$(mktemp -d)
-          cp -r packages/cli/* "$TEMP_DIR/"
-          cd "$TEMP_DIR"
+          cd packages/cli
           
           # Modify package.json for unscoped publish
           node -e "
@@ -172,8 +170,9 @@ jobs:
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
           
-          npm publish --access public
-          cd - && rm -rf "$TEMP_DIR"
+          # Use yarn npm publish to maintain workspace dependency resolution
+          yarn npm publish --access public
+          cd ../..
           
           echo "All packages published successfully!"
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,6 +35,16 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "📌 Expected version: $VERSION"
+          
+          # Determine npm tag based on version format
+          if [[ "$VERSION" =~ -[0-9]+$ ]]; then
+            NPM_TAG="alpha"
+            echo "🚨 Decorated version detected, using --tag alpha"
+          else
+            NPM_TAG="latest"
+            echo "✅ Stable version, using --tag latest"
+          fi
+          echo "NPM_TAG=$NPM_TAG" >> $GITHUB_OUTPUT
 
       - name: Verify package versions match tag
         run: |
@@ -119,42 +129,43 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -e
+          NPM_TAG="${{ steps.extract_version.outputs.NPM_TAG }}"
           
           echo "Publishing @vue-skuilder/common..."
-          cd packages/common && yarn npm publish --access public && cd ../..
+          cd packages/common && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/db..."
-          cd packages/db && yarn npm publish --access public && cd ../..
+          cd packages/db && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/common-ui..."
-          cd packages/common-ui && yarn npm publish --access public && cd ../..
+          cd packages/common-ui && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/edit-ui..."
-          cd packages/edit-ui && yarn npm publish --access public && cd ../..
+          cd packages/edit-ui && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/courseware..."
-          cd packages/courseware && yarn npm publish --access public && cd ../..
+          cd packages/courseware && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/client..."
-          cd packages/client && yarn npm publish --access public && cd ../..
+          cd packages/client && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/platform-ui..."
-          cd packages/platform-ui && yarn npm publish --access public && cd ../..
+          cd packages/platform-ui && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/standalone-ui..."
-          cd packages/standalone-ui && yarn npm publish --access public && cd ../..
+          cd packages/standalone-ui && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/mcp..."
-          cd packages/mcp && yarn npm publish --access public && cd ../..
+          cd packages/mcp && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           # echo "Publishing @vue-skuilder/tuilder..."
-          # cd packages/tuilder && yarn npm publish --access public && cd ../..
+          # cd packages/tuilder && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/express..."
-          cd packages/express && yarn npm publish --access public && cd ../..
+          cd packages/express && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           echo "Publishing @vue-skuilder/cli (scoped)..."
-          cd packages/cli && yarn npm publish --access public && cd ../..
+          cd packages/cli && yarn npm publish --access public --tag $NPM_TAG && cd ../..
           
           # Dual-publish CLI as unscoped 'skuilder' package
           echo "Publishing CLI as 'skuilder'..."
@@ -171,7 +182,7 @@ jobs:
           "
           
           # Use yarn npm publish to maintain workspace dependency resolution
-          yarn npm publish --access public
+          yarn npm publish --access public --tag $NPM_TAG
           cd ../..
           
           echo "All packages published successfully!"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "vue-skuilder",
     "scripts": {
         "setup": "yarn && git submodule update --init --recursive && yarn build:lib",
-        "dev": "yarn workspace @vue-skuilder/common build && yarn workspace @vue-skuilder/db build && yarn workspace @vue-skuilder/common-ui build && yarn workspace @vue-skuilder/courseware build && yarn workspace @vue-skuilder/edit-ui build && node scripts/dev-couchdb.js start && concurrently \"yarn dev:platform-ui\" \"yarn dev:express\"",
         "dev:watch": "node scripts/dev-watch.js",
         "dev:platform": "yarn couchdb:start && yarn workspace @vue-skuilder/express dev & yarn workspace @vue-skuilder/platform-ui dev",
         "couchdb:start": "node scripts/dev-couchdb.js start",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "type": "module",
   "description": "CLI scaffolding tool for vue-skuilder projects",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "type": "module",
   "description": "CLI scaffolding tool for vue-skuilder projects",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "type": "module",
   "description": "CLI scaffolding tool for vue-skuilder projects",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "type": "module",
   "description": "CLI scaffolding tool for vue-skuilder projects",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "type": "module",
   "description": "CLI scaffolding tool for vue-skuilder projects",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "main": "./dist/common-ui.umd.js",
   "module": "./dist/common-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "main": "./dist/common-ui.umd.js",
   "module": "./dist/common-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "main": "./dist/common-ui.umd.js",
   "module": "./dist/common-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "main": "./dist/common-ui.umd.js",
   "module": "./dist/common-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "main": "./dist/common-ui.umd.js",
   "module": "./dist/common-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/courseware/package.json
+++ b/packages/courseware/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "type": "module",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.mjs",

--- a/packages/courseware/package.json
+++ b/packages/courseware/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "type": "module",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.mjs",

--- a/packages/courseware/package.json
+++ b/packages/courseware/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "type": "module",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.mjs",

--- a/packages/courseware/package.json
+++ b/packages/courseware/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "type": "module",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.mjs",

--- a/packages/courseware/package.json
+++ b/packages/courseware/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "type": "module",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.mjs",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "description": "Database layer for vue-skuilder",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "description": "Database layer for vue-skuilder",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "description": "Database layer for vue-skuilder",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "description": "Database layer for vue-skuilder",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "description": "Database layer for vue-skuilder",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/db/src/impl/couch/PouchDataLayerProvider.ts
+++ b/packages/db/src/impl/couch/PouchDataLayerProvider.ts
@@ -9,6 +9,7 @@ import {
   UserDBInterface,
 } from '../../core/interfaces';
 import { logger } from '../../util/logger';
+import { initializeDataDirectory } from '../../util/dataDirectory';
 
 import { getLoggedInUsername } from './auth';
 
@@ -45,6 +46,7 @@ export class CouchDataLayerProvider implements DataLayerProvider {
       logger.info(
         'CouchDataLayerProvider: Running in Node.js environment, creating guest UserDB for testing.'
       );
+      await initializeDataDirectory();
       // In Node.js (testing) environment, create a guest user instance
       const syncStrategy = new CouchDBSyncStrategy();
       this.userDB = await BaseUser.instance(syncStrategy);

--- a/packages/edit-ui/package.json
+++ b/packages/edit-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "main": "./dist/edit-ui.umd.js",
   "module": "./dist/edit-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/edit-ui/package.json
+++ b/packages/edit-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "main": "./dist/edit-ui.umd.js",
   "module": "./dist/edit-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/edit-ui/package.json
+++ b/packages/edit-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "main": "./dist/edit-ui.umd.js",
   "module": "./dist/edit-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/edit-ui/package.json
+++ b/packages/edit-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "main": "./dist/edit-ui.umd.js",
   "module": "./dist/edit-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/edit-ui/package.json
+++ b/packages/edit-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "main": "./dist/edit-ui.umd.js",
   "module": "./dist/edit-ui.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/express/.env.development
+++ b/packages/express/.env.development
@@ -6,4 +6,6 @@ COUCHDB_PROTOCOL=http
 COUCHDB_ADMIN=admin
 COUCHDB_PASSWORD=password
 
+NODE_ENV=platform
+
 VERSION=localdev

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "description": "an API",
   "main": "dist/app.js",
   "type": "module",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "description": "an API",
   "main": "dist/app.js",
   "type": "module",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "description": "an API",
   "main": "dist/app.js",
   "type": "module",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "description": "an API",
   "main": "dist/app.js",
   "type": "module",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "description": "an API",
   "main": "dist/app.js",
   "type": "module",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "build:examples": "tsup --entry src/examples/local-dev.ts --format cjs,esm --outDir dist --target es2022",
+    "build:examples": "tsup src/examples/local-dev.ts --format cjs,esm --outDir dist/examples --target es2022",
     "dev": "yarn build && yarn build:examples && yarn inspector",
     "inspector": "npx @modelcontextprotocol/inspector node dist/examples/local-dev.mjs",
     "test:cli": "npx @modelcontextprotocol/inspector --cli node dist/examples/local-dev.mjs",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-skuilder/mcp",
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-skuilder/mcp",
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-skuilder/mcp",
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-skuilder/mcp",
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-skuilder/mcp",
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp/src/examples/local-dev.ts
+++ b/packages/mcp/src/examples/local-dev.ts
@@ -8,8 +8,6 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 const TEST_COURSE_ID = '2aeb8315ef78f3e89ca386992d00825b';
 
 async function main() {
-  return;
-
   try {
     console.error('Starting local-dev example Vue-Skuilder MCP Server...');
     console.error(`Using test course: ${TEST_COURSE_ID}`);

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/standalone-ui/package.json
+++ b/packages/standalone-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "v0.1.8-4",
+  "version": "0.1.8-4",
   "type": "module",
   "main": "./dist-lib/questions.cjs.js",
   "module": "./dist-lib/questions.mjs",

--- a/packages/standalone-ui/package.json
+++ b/packages/standalone-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-6",
+  "version": "0.1.8-7",
   "type": "module",
   "main": "./dist-lib/questions.cjs.js",
   "module": "./dist-lib/questions.mjs",

--- a/packages/standalone-ui/package.json
+++ b/packages/standalone-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-3",
+  "version": "v0.1.8-4",
   "type": "module",
   "main": "./dist-lib/questions.cjs.js",
   "module": "./dist-lib/questions.mjs",

--- a/packages/standalone-ui/package.json
+++ b/packages/standalone-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-4",
+  "version": "0.1.8-5",
   "type": "module",
   "main": "./dist-lib/questions.cjs.js",
   "module": "./dist-lib/questions.mjs",

--- a/packages/standalone-ui/package.json
+++ b/packages/standalone-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8-5",
+  "version": "0.1.8-6",
   "type": "module",
   "main": "./dist-lib/questions.cjs.js",
   "module": "./dist-lib/questions.mjs",

--- a/scripts/vtag.js
+++ b/scripts/vtag.js
@@ -27,6 +27,12 @@ function main() {
     console.error('Example: node vtag.js 0.1.8-3');
     process.exit(1);
   }
+  if (tagString.startsWith('v')) {
+    console.error(
+      'Version string should not start with "v". Please provide a version like "0.1.8-3", "0.2.5", etc.'
+    );
+    process.exit(1);
+  }
 
   console.log(`🏷️  Setting all packages to version: ${tagString}`);
 
@@ -58,11 +64,11 @@ function main() {
   }
 
   console.log(`\n📦 Updating yarn lockfile...`);
-  
+
   // Run yarn to update lockfile
   const yarnProcess = spawn('yarn', ['install'], {
     stdio: 'inherit',
-    cwd: path.join(__dirname, '..')
+    cwd: path.join(__dirname, '..'),
   });
 
   yarnProcess.on('close', (yarnCode) => {
@@ -76,8 +82,8 @@ function main() {
 
     // Commit the changes
     const commitProcess = spawn('git', ['commit', '-am', `bump: version ${tagString}`], {
-      stdio: 'inherit', 
-      cwd: path.join(__dirname, '..')
+      stdio: 'inherit',
+      cwd: path.join(__dirname, '..'),
     });
 
     commitProcess.on('close', (commitCode) => {
@@ -92,7 +98,7 @@ function main() {
       // Create git tag
       const gitProcess = spawn('git', ['tag', `v${tagString}`], {
         stdio: 'inherit',
-        cwd: path.join(__dirname, '..')
+        cwd: path.join(__dirname, '..'),
       });
 
       gitProcess.on('close', (code) => {


### PR DESCRIPTION
Recovering from some package and script refactors.

PR fixes a variety of dev config errors that knocked much of the e2e testing out of whack. Most previously existing tests should now be running and reporting correctly.

- **bump: version v0.1.8-4**
- **bump: version 0.1.8-4**
- **use yarn npm publish...**
- **bump: version 0.1.8-5**
- **distinguish ahpla and stable npm releases**
- **check against vvX.Y.Z tag**
- **bump: version 0.1.8-6**
- **fix: update e2e workflow script call**
- **bump: version 0.1.8-7**
- **update: use build:examples for local-dev build**
- **rm early return**
- **udpate build script**
- **build library packages for e2e test**
- **set node_env var for devenv**
- **set a wait timeout**
