### PR TITLE
skip srs hooks

### DIFF
--- a/packages/db/src/core/navigators/generators/srs.ts
+++ b/packages/db/src/core/navigators/generators/srs.ts
@@ -131,7 +131,29 @@ export default class SRSNavigator extends ContentNavigator implements CardGenera
     const now = moment.utc();
 
     // Filter to only cards that are actually due
-    const dueReviews = reviews.filter((r) => now.isAfter(moment.utc(r.reviewTime)));
+    let dueReviews = reviews.filter((r) => now.isAfter(moment.utc(r.reviewTime)));
+
+    // Remove scheduled reviews for cards tagged srs:skip (e.g. intro cards).
+    // These were scheduled before the tag convention existed — clean them up.
+    if (dueReviews.length > 0) {
+      const dueCardIds = [...new Set(dueReviews.map((r) => r.cardId))];
+      const tagsByCard = await this.course!.getAppliedTagsBatch(dueCardIds);
+      const skippedReviewIds: string[] = [];
+      dueReviews = dueReviews.filter((r) => {
+        const tags = tagsByCard.get(r.cardId) ?? [];
+        if (tags.includes('srs:skip')) {
+          skippedReviewIds.push(r._id);
+          return false;
+        }
+        return true;
+      });
+      if (skippedReviewIds.length > 0) {
+        logger.info(`[SRS] Removing ${skippedReviewIds.length} scheduled reviews for srs:skip cards`);
+        for (const id of skippedReviewIds) {
+          void this.user!.removeScheduledCardReview(id);
+        }
+      }
+    }
 
     // Compute backlog pressure - applies globally to all reviews
     const backlogPressure = this.computeBacklogPressure(dueReviews.length);

--- a/packages/db/src/study/services/ResponseProcessor.ts
+++ b/packages/db/src/study/services/ResponseProcessor.ts
@@ -173,7 +173,11 @@ export class ResponseProcessor {
     // Only schedule and update ELO for first-time attempts
     if (cardRecord.priorAttemps === 0) {
       // Schedule the card for future review based on performance (async, non-blocking)
-      void this.srsService.scheduleReview(history, studySessionItem);
+      // Cards tagged srs:skip are one-time presentations (e.g. intro cards) — no review scheduling
+      const skipSrs = currentCard.card.tags.includes('srs:skip');
+      if (!skipSrs) {
+        void this.srsService.scheduleReview(history, studySessionItem);
+      }
 
       // Parse performance (may be numeric or structured)
       const { globalScore, taggedPerformance } = this.parsePerformance(cardRecord.performance);


### PR DESCRIPTION
- **do not schedule cards marked `srs:skip` for srs**
- **rm items tagged as non-srs**
