### PR TITLE
refactor(platform-ui): extract createPlatformApp + createAppRouter factories

### DIFF
--- a/packages/platform-ui/src/createPlatformApp.ts
+++ b/packages/platform-ui/src/createPlatformApp.ts
@@ -1,0 +1,125 @@
+import 'roboto-fontface/css/roboto/roboto-fontface.css';
+import { createApp, type App as VueApp, type Plugin } from 'vue';
+import { createPinia, type Pinia } from 'pinia';
+import type { Router, RouteRecordRaw } from 'vue-router';
+
+import App from './App.vue';
+import defaultVuetify from './plugins/vuetify';
+import { createAppRouter } from './router';
+import ENV, { type Environment } from './ENVIRONMENT_VARS';
+
+// styles from component library packages
+import '@vue-skuilder/courseware/style';
+import '@vue-skuilder/common-ui/style';
+
+// `db` import and initialization
+import { initializeDataLayer } from '@vue-skuilder/db';
+
+export interface PlatformAppOptions {
+  /**
+   * Mount target. May be a CSS selector or an Element. Defaults to '#app'
+   * (overridable per-call in {@link PlatformApp.mount}).
+   */
+  el?: string | Element;
+  /**
+   * Data-layer environment overrides (CouchDB / Express URLs). Merged over the
+   * ambient `window.__SKUILDER_ENV__` / process.env-derived defaults, so a host
+   * need only specify what differs.
+   */
+  env?: Partial<Environment>;
+  /**
+   * Vuetify instance — the branding seam. Defaults to the built-in eduQuilt
+   * theme. A consuming app (e.g. diffdoc) passes its own themed
+   * `createVuetify(...)` here.
+   */
+  vuetify?: Plugin;
+  /**
+   * Routes appended after the built-in platform routes — the primary UI
+   * extension seam for consuming apps (e.g. diffdoc's drift-queue views).
+   */
+  extraRoutes?: RouteRecordRaw[];
+  /**
+   * Inline components made available to MarkdownRenderer via the
+   * `markdownComponents` provide. Defaults to `{}`.
+   */
+  markdownComponents?: Record<string, unknown>;
+}
+
+export interface PlatformApp {
+  app: VueApp;
+  router: Router;
+  pinia: Pinia;
+  /** Mount the app. `el` defaults to {@link PlatformAppOptions.el} ?? '#app'. */
+  mount: (el?: string | Element) => void;
+}
+
+/**
+ * Construct (but do not necessarily mount) the platform-ui application.
+ *
+ * This is the consumable entry point for the multi-tenant Skuilder shell.
+ * `src/main.ts` is now a thin default host that calls this with no options;
+ * external apps import `createPlatformApp` from the package entry and supply
+ * their own `env` / `vuetify` (branding) / `extraRoutes`.
+ *
+ * Note: PWA service-worker registration is intentionally NOT performed here —
+ * it is an app-shell concern handled by `main.ts` (`./registerServiceWorker`),
+ * so library consumers do not inherit eduQuilt's service worker.
+ */
+export async function createPlatformApp(options: PlatformAppOptions = {}): Promise<PlatformApp> {
+  const env: Environment = { ...ENV, ...options.env };
+
+  await initializeDataLayer({
+    type: 'couch',
+    options: {
+      COUCHDB_SERVER_PROTOCOL: env.COUCHDB_SERVER_PROTOCOL,
+      COUCHDB_SERVER_URL: env.COUCHDB_SERVER_URL,
+    },
+  });
+
+  const pinia = createPinia();
+  const app = createApp(App);
+
+  // Dynamically import { allCourseWare } and register all built-in courses.
+  // As of the courseware tree-shaking refactor, `allCourseWare` starts empty;
+  // platform-ui historically depended on all subcourses being available, so
+  // we eagerly load them all here. See packages/courseware/src/index.ts.
+  const {
+    allCourseWare: Courses,
+    defaultCourse,
+    loadAllSubcourses,
+  } = await import('@vue-skuilder/courseware');
+  if (!Courses.courses.find((c) => c.name === defaultCourse.name)) {
+    Courses.courses.push(defaultCourse);
+  }
+  await loadAllSubcourses();
+
+  // Register all view components globally
+  const viewComponents = Courses.allViewsRaw();
+  Object.entries(viewComponents).forEach(([name, component]) => {
+    app.component(name, component);
+  });
+
+  const router = createAppRouter({ extraRoutes: options.extraRoutes });
+
+  app.use(router);
+  app.use(options.vuetify ?? defaultVuetify);
+  app.use(pinia);
+
+  // Dynamically import piniaPlugin
+  const { piniaPlugin } = await import('@vue-skuilder/common-ui');
+  app.use(piniaPlugin, { pinia });
+
+  // Provide inline markdown components for MarkdownRenderer
+  // Enables custom Vue components in markdown via {{ <component-name /> }} syntax
+  // See docs: https://patched-network.github.io/vue-skuilder/do/inline-components
+  app.provide('markdownComponents', options.markdownComponents ?? {});
+
+  return {
+    app,
+    router,
+    pinia,
+    mount: (el: string | Element = options.el ?? '#app') => {
+      app.mount(el);
+    },
+  };
+}

--- a/packages/platform-ui/src/index.ts
+++ b/packages/platform-ui/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Public entry for `@vue-skuilder/platform-ui` consumed as a library.
+ *
+ * This declares the intended consumable surface for hosting apps (e.g. diffdoc)
+ * that want the multi-tenant Skuilder shell with their own branding + routes.
+ *
+ * NOTE: a library build target is not yet wired in `vite.config.js`. This entry
+ * is type-checked and is the agreed API surface, but `build:lib` + a
+ * consumed-lib smoke test land in the follow-up PR (which is what makes a lib
+ * build trustworthy — the existing E2E only exercises pui-as-an-app). Until
+ * then the default app entry remains `src/main.ts`.
+ */
+export { createPlatformApp } from './createPlatformApp';
+export type { PlatformAppOptions, PlatformApp } from './createPlatformApp';
+
+export { createAppRouter, platformRoutes } from './router';
+export type { CreateAppRouterOptions } from './router';
+
+// The root shell component + default theme, exposed so a host can compose or
+// re-theme rather than replace the shell.
+export { default as PlatformAppRoot } from './App.vue';
+export { default as defaultVuetify } from './plugins/vuetify';
+
+export type { Environment } from './ENVIRONMENT_VARS';

--- a/packages/platform-ui/src/main.ts
+++ b/packages/platform-ui/src/main.ts
@@ -1,66 +1,13 @@
-import ENV from './ENVIRONMENT_VARS';
-
-import 'roboto-fontface/css/roboto/roboto-fontface.css';
-import { createApp } from 'vue';
-import App from './App.vue';
+// Default eduQuilt host entry.
+//
+// All app construction now lives in `createPlatformApp` (the consumable
+// library surface — see ./index.ts). This entry exists only to (a) register
+// the PWA service worker, which is an app-shell concern that library consumers
+// must NOT inherit, and (b) boot the shell with built-in defaults and mount it.
+//
+// Consuming apps (e.g. diffdoc) should import `createPlatformApp` from
+// `@vue-skuilder/platform-ui` and supply their own env / theme / routes.
 import './registerServiceWorker';
-import router from './router';
-import { createPinia } from 'pinia';
-import vuetify from './plugins/vuetify';
+import { createPlatformApp } from './createPlatformApp';
 
-// styles from component library packages
-import '@vue-skuilder/courseware/style';
-import '@vue-skuilder/common-ui/style';
-
-// `db` import and initialization
-import { initializeDataLayer } from '@vue-skuilder/db';
-
-(async () => {
-  await initializeDataLayer({
-    type: 'couch',
-    options: {
-      COUCHDB_SERVER_PROTOCOL: ENV.COUCHDB_SERVER_PROTOCOL,
-      COUCHDB_SERVER_URL: ENV.COUCHDB_SERVER_URL,
-    },
-  });
-
-  const pinia = createPinia();
-  const app = createApp(App);
-
-  // Dynamically import { allCourseWare } and register all built-in courses.
-  // As of the courseware tree-shaking refactor, `allCourseWare` starts empty;
-  // platform-ui historically depended on all subcourses being available, so
-  // we eagerly load them all here. See packages/courseware/src/index.ts.
-  const {
-    allCourseWare: Courses,
-    defaultCourse,
-    loadAllSubcourses,
-  } = await import('@vue-skuilder/courseware');
-  if (!Courses.courses.find((c) => c.name === defaultCourse.name)) {
-    Courses.courses.push(defaultCourse);
-  }
-  await loadAllSubcourses();
-
-  // Register all view components globally
-  const viewComponents = Courses.allViewsRaw();
-  Object.entries(viewComponents).forEach(([name, component]) => {
-    app.component(name, component);
-  });
-
-  app.use(router);
-  app.use(vuetify);
-  app.use(pinia);
-
-  // Dynamically import piniaPlugin
-  const { piniaPlugin } = await import('@vue-skuilder/common-ui');
-  app.use(piniaPlugin, { pinia });
-
-  // Provide inline markdown components for MarkdownRenderer
-  // Enables custom Vue components in markdown via {{ <component-name /> }} syntax
-  // See docs: https://patched-network.github.io/vue-skuilder/do/inline-components
-  app.provide('markdownComponents', {
-    // Empty - add components as needed
-  });
-
-  app.mount('#app');
-})();
+void createPlatformApp().then(({ mount }) => mount('#app'));

--- a/packages/platform-ui/src/router.ts
+++ b/packages/platform-ui/src/router.ts
@@ -1,7 +1,7 @@
 import { getCurrentUser } from '@vue-skuilder/common-ui';
 import { useAuthRedirectStore } from './stores/useAuthRedirectStore';
 import { isRegistrationEnabled } from './utils/registrationGuard';
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createWebHistory, type RouteRecordRaw, type Router } from 'vue-router';
 
 // Eager: landing and auth-flow views (needed for first paint / common entry)
 import Home from './views/Home.vue';
@@ -32,198 +32,241 @@ const MarkdownRenderer = () => import('@vue-skuilder/common-ui').then((m) => m.M
 // builds entirely.
 const Playtest = () => import('./dev/Playtest.vue');
 
-const router = createRouter({
-  history: createWebHistory(),
-  // mode: 'history', // deprecated in Vue 3 / Vue Router 4
-
-  routes: [
-    // Dev-only playtest harness — see ./dev/Playtest.vue. The route is
-    // only registered when Vite is in dev mode, so prod builds neither
-    // expose the URL nor include the chunk.
-    ...(import.meta.env.DEV
-      ? [
-          {
-            path: '/play/:pathMatch(.*)?',
-            name: 'playtest',
-            component: Playtest,
-            props: true,
-          },
-        ]
-      : []),
-    {
-      path: '/md',
-      component: MarkdownRenderer,
-    },
-    {
-      path: '/',
-      alias: ['/home'],
-      name: 'home',
-      component: Home,
-    },
-    {
-      path: '/about',
-      name: 'about',
-      component: About,
-    },
-    {
-      path: '/login',
-      name: 'login',
-      component: Login,
-    },
-    {
-      path: '/signup',
-      name: 'signup',
-      component: SignUp,
-      beforeEnter: () => {
-        if (!isRegistrationEnabled()) {
-          return { name: 'home' };
-        }
-      },
-    },
-    {
-      path: '/verify',
-      name: 'verify',
-      component: VerifyEmailView,
-    },
-    {
-      path: '/request-reset',
-      name: 'request-reset',
-      component: RequestPasswordResetView,
-    },
-    {
-      path: '/reset-password',
-      name: 'reset-password',
-      component: ResetPasswordView,
-    },
-    {
-      path: '/notes',
-      component: ReleaseNotes,
-    },
-    {
-      path: '/edit/:course',
-      props: true,
-      component: CourseEditor,
-    },
-    {
-      path: '/study',
-      name: 'study',
-      component: Study,
-    },
-    {
-      path: '/study/:focusCourseID',
-      component: Study,
-      props: true,
-    },
-    {
-      path: '/random',
-      name: 'random',
-      alias: ['/r'],
-      props: {
-        randomPreview: true,
-      },
-      component: Study,
-    },
-    {
-      path: '/classrooms',
-      name: 'classrooms',
-      component: Classrooms,
-    },
-    {
-      path: '/classrooms/:classroomId',
-      props: true,
-      alias: '/c/:classroomId',
-      component: ClassroomCtrlPanel,
-    },
-    {
-      path: '/classrooms/:classroomId/code',
-      props: true,
-      alias: '/c/:classroomId',
-      component: JoinCode,
-    },
-    {
-      path: '/courses',
-      alias: ['/quilts', '/q'],
-      component: Courses,
-    },
-    {
-      path: '/courses/:query',
-      props: true,
-      alias: ['/quilts/:query', '/q/:query'],
-      component: CourseRouter,
-    },
-    {
-      path: '/courses/:courseId/elo',
-      props: true,
-      alias: ['/quilts/:courseId/elo', '/q/:courseId/elo'],
-      component: ELOModerator,
-    },
-    {
-      path: '/courses/:courseId/tags/:tagId',
-      props: true,
-      alias: ['/quilts/:courseId/tags/:tagId', '/q/:courseId/tags/:tagId'],
-      component: TagInformation,
-    },
-    {
-      path: '/courses/:previewCourseID/preview',
-      props: true,
-      alias: ['/quilts/:previewCourseID/preview', '/q/:previewCourseID/preview'],
-      component: Study,
-    },
-    {
-      path: '/admin',
-      component: AdminDashboard,
-      meta: { requiresAdmin: true },
-    },
-    {
-      path: '/user/:username',
-      alias: '/u/:username',
-      props: true,
-      component: User,
-      children: [
+/**
+ * The built-in platform-ui routes (the eduQuilt / diffdoc multi-tenant shell).
+ *
+ * Exported so a consuming application can inspect or selectively reuse them.
+ * Most hosts should instead append their own views via the `extraRoutes`
+ * option of {@link createAppRouter} rather than reconstructing this array.
+ */
+export const platformRoutes: RouteRecordRaw[] = [
+  // Dev-only playtest harness — see ./dev/Playtest.vue. The route is
+  // only registered when Vite is in dev mode, so prod builds neither
+  // expose the URL nor include the chunk.
+  ...(import.meta.env.DEV
+    ? [
         {
-          path: 'new',
-          component: User,
-        }, //,
-        // {
-        //   path: '/stats',
-        //   component: Stats,
-        // },
-      ],
+          path: '/play/:pathMatch(.*)?',
+          name: 'playtest',
+          component: Playtest,
+          props: true,
+        },
+      ]
+    : []),
+  {
+    path: '/md',
+    component: MarkdownRenderer,
+  },
+  {
+    path: '/',
+    alias: ['/home'],
+    name: 'home',
+    component: Home,
+  },
+  {
+    path: '/about',
+    name: 'about',
+    component: About,
+  },
+  {
+    path: '/login',
+    name: 'login',
+    component: Login,
+  },
+  {
+    path: '/signup',
+    name: 'signup',
+    component: SignUp,
+    beforeEnter: () => {
+      if (!isRegistrationEnabled()) {
+        return { name: 'home' };
+      }
     },
-    {
-      path: '/user/:_id/stats',
-      props: true,
-      alias: ['/u/:_id/stats'],
-      component: Stats,
+  },
+  {
+    path: '/verify',
+    name: 'verify',
+    component: VerifyEmailView,
+  },
+  {
+    path: '/request-reset',
+    name: 'request-reset',
+    component: RequestPasswordResetView,
+  },
+  {
+    path: '/reset-password',
+    name: 'reset-password',
+    component: ResetPasswordView,
+  },
+  {
+    path: '/notes',
+    component: ReleaseNotes,
+  },
+  {
+    path: '/edit/:course',
+    props: true,
+    component: CourseEditor,
+  },
+  {
+    path: '/study',
+    name: 'study',
+    component: Study,
+  },
+  {
+    path: '/study/:focusCourseID',
+    component: Study,
+    props: true,
+  },
+  {
+    path: '/random',
+    name: 'random',
+    alias: ['/r'],
+    props: {
+      randomPreview: true,
     },
-  ],
-});
+    component: Study,
+  },
+  {
+    path: '/classrooms',
+    name: 'classrooms',
+    component: Classrooms,
+  },
+  {
+    path: '/classrooms/:classroomId',
+    props: true,
+    alias: '/c/:classroomId',
+    component: ClassroomCtrlPanel,
+  },
+  {
+    path: '/classrooms/:classroomId/code',
+    props: true,
+    alias: '/c/:classroomId',
+    component: JoinCode,
+  },
+  {
+    path: '/courses',
+    alias: ['/quilts', '/q'],
+    component: Courses,
+  },
+  {
+    path: '/courses/:query',
+    props: true,
+    alias: ['/quilts/:query', '/q/:query'],
+    component: CourseRouter,
+  },
+  {
+    path: '/courses/:courseId/elo',
+    props: true,
+    alias: ['/quilts/:courseId/elo', '/q/:courseId/elo'],
+    component: ELOModerator,
+  },
+  {
+    path: '/courses/:courseId/tags/:tagId',
+    props: true,
+    alias: ['/quilts/:courseId/tags/:tagId', '/q/:courseId/tags/:tagId'],
+    component: TagInformation,
+  },
+  {
+    path: '/courses/:previewCourseID/preview',
+    props: true,
+    alias: ['/quilts/:previewCourseID/preview', '/q/:previewCourseID/preview'],
+    component: Study,
+  },
+  {
+    path: '/admin',
+    component: AdminDashboard,
+    meta: { requiresAdmin: true },
+  },
+  {
+    path: '/user/:username',
+    alias: '/u/:username',
+    props: true,
+    component: User,
+    children: [
+      {
+        path: 'new',
+        component: User,
+      }, //,
+      // {
+      //   path: '/stats',
+      //   component: Stats,
+      // },
+    ],
+  },
+  {
+    path: '/user/:_id/stats',
+    props: true,
+    alias: ['/u/:_id/stats'],
+    component: Stats,
+  },
+];
 
-router.beforeEach(async (to, _from, next) => {
-  // paths that should be handled by the server, not the SPA
-  const apiPaths = ['/express', '/couch'];
+export interface CreateAppRouterOptions {
+  /**
+   * Additional routes appended after the built-in {@link platformRoutes}.
+   * This is the primary extension seam for consuming apps (e.g. diffdoc's
+   * drift-queue / reconciliation views).
+   */
+  extraRoutes?: RouteRecordRaw[];
+}
 
-  if (apiPaths.some((path) => to.path.startsWith(path))) {
-    // Return false to cancel navigation and let the browser handle the request
-    return false;
-  }
+/**
+ * Build the platform-ui router.
+ *
+ * This module previously exported a singleton router instance. It is now a
+ * factory so that consuming applications can inject their own routes and own
+ * the Vue app lifecycle (see {@link createPlatformApp}). The default eduQuilt
+ * host obtains its router via `createPlatformApp()` with no `extraRoutes`,
+ * preserving prior behaviour exactly.
+ */
+export function createAppRouter(options: CreateAppRouterOptions = {}): Router {
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [...platformRoutes, ...(options.extraRoutes ?? [])],
+  });
 
-  if (to.meta.requiresAdmin) {
-    try {
-      const user = await getCurrentUser();
-      if (user && user.getUsername() === 'admin') {
-        next();
-      } else {
-        const redirectStore = useAuthRedirectStore();
-        let reason: 'admin-required' | 'auth-required' | 'auth-failed';
+  router.beforeEach(async (to, _from, next) => {
+    // paths that should be handled by the server, not the SPA
+    const apiPaths = ['/express', '/couch'];
 
-        if (user) {
-          // User is logged in but not admin
-          reason = 'admin-required';
+    if (apiPaths.some((path) => to.path.startsWith(path))) {
+      // Return false to cancel navigation and let the browser handle the request
+      return false;
+    }
+
+    if (to.meta.requiresAdmin) {
+      try {
+        const user = await getCurrentUser();
+        if (user && user.getUsername() === 'admin') {
+          next();
         } else {
-          // User is not logged in
-          reason = 'auth-required';
+          const redirectStore = useAuthRedirectStore();
+          let reason: 'admin-required' | 'auth-required' | 'auth-failed';
+
+          if (user) {
+            // User is logged in but not admin
+            reason = 'admin-required';
+          } else {
+            // User is not logged in
+            reason = 'auth-required';
+          }
+
+          // Set context in store (fallback for refresh)
+          redirectStore.setPendingRedirect(to.fullPath, reason);
+
+          // Navigate with history state (primary method)
+          next({
+            name: 'login',
+            state: {
+              redirect: to.fullPath,
+              reason,
+              timestamp: Date.now(),
+            },
+          });
         }
+      } catch {
+        const redirectStore = useAuthRedirectStore();
+        const reason = 'auth-failed';
 
         // Set context in store (fallback for refresh)
         redirectStore.setPendingRedirect(to.fullPath, reason);
@@ -238,26 +281,10 @@ router.beforeEach(async (to, _from, next) => {
           },
         });
       }
-    } catch {
-      const redirectStore = useAuthRedirectStore();
-      const reason = 'auth-failed';
-
-      // Set context in store (fallback for refresh)
-      redirectStore.setPendingRedirect(to.fullPath, reason);
-
-      // Navigate with history state (primary method)
-      next({
-        name: 'login',
-        state: {
-          redirect: to.fullPath,
-          reason,
-          timestamp: Date.now(),
-        },
-      });
+    } else {
+      next();
     }
-  } else {
-    next();
-  }
-});
+  });
 
-export default router;
+  return router;
+}


### PR DESCRIPTION
Promote platform-ui toward a consumable shell so diffdoc (and future apps) can host the multi-tenant Skuilder shell with their own env/theme/routes, instead of forking it into the commercial repo.

- router.ts: singleton -> createAppRouter({ extraRoutes }); export platformRoutes
- createPlatformApp.ts (new): app-construction factory lifted verbatim from main.ts and parameterized (env, vuetify[branding], extraRoutes, markdownComponents)
- main.ts: thin default eduQuilt host; retains PWA service-worker registration so library consumers do not inherit it
- index.ts (new): declared library surface (API ratify target)

Behaviour-preserving: default host boots through createPlatformApp() with no options. build:lib + consumed-lib smoke test deferred to follow-up PR (existing E2E only covers pui-as-an-app). Local: lint clean, vite build ok, test:unit 8/8, vue-tsc clean on new files.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
